### PR TITLE
Add: 投稿の検索機能（キーワード・カテゴリー）を実装し、レイアウトを調整

### DIFF
--- a/app/assets/stylesheets/public/searches.scss
+++ b/app/assets/stylesheets/public/searches.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/searches controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -19,7 +19,19 @@ class Public::PostsController < ApplicationController
   end
 
   def index
-    @posts = Post.page(params[:page])
+    @posts = Post.includes(:genre, :member)
+    @genres = Genre.all
+
+    if params[:keyword].present?
+      kw = "%#{params[:keyword]}%"
+      @posts = @posts.where("posts.title LIKE :kw OR posts.body LIKE:kw OR members.name LIKE :kw", kw: kw).joins(:member)
+    end
+
+    if params[:genre_ids].present?
+      @posts = @posts.where(genre_id: params[:genre_ids])
+    end
+
+    @posts = @posts.page(params[:page])
   end
 
   def show

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -41,7 +41,7 @@
     <%= image_tag post.get_image(600, 500), alt: "投稿画像", class: "card-img-top", style: "max-height: 500px; object-fit: cover;" %>
     <div class="card-body">
       <h4 class="card-title"><%= post.title %></h4>
-      <p class="card-text">投稿の内容:<%= post.genre.present? ? post.genre.name : "未選択" %></p>
+      <p class="card-text">投稿の種類：<%= post.genre.present? ? post.genre.name : "未選択" %></p>
       <p class="card-text"><%= post.body %></p>
     </div>
   </div>

--- a/app/views/public/posts/_post_list.html.erb
+++ b/app/views/public/posts/_post_list.html.erb
@@ -1,0 +1,16 @@
+<% @posts.each do |post| %>
+  <div class="card w-50 mx-auto mt-4">
+    <div class="card-header bg-white d-flex align-items-center">
+      <%= link_to member_path(post.member), class: "text-decoration-none link-dark d-flex align-items-center" do %>  
+        <%= image_tag post.member.get_profile_image(50, 50), alt: "プロフィール画像", class: "rounded-circle me-3" %> 
+        <span><%= post.member.name %></span>
+      <% end %> 
+    </div>
+    <%= image_tag post.get_image(600, 500), alt: "投稿画像", class: "card-img-top", style: "max-height: 500px; object-fit: cover;" %>
+    <div class="card-body">
+      <h4 class="card-title"><%= post.title %></h4>
+      <p class="card-text">投稿の種類：<%= post.genre.present? ? post.genre.name : "未選択" %></p>
+      <p class="card-text"><%= post.body %></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/public/posts/_search_form.html.erb
+++ b/app/views/public/posts/_search_form.html.erb
@@ -1,0 +1,42 @@
+<div class="w-50 mx-auto">
+  <div class="container bg-light rounded-3 py-5 px-4 align-items-center justify-content-between">
+    <div class="search-form-area">
+      <%= form_with url: posts_path, method: :get do |f| %>
+        <div class="d-flex justify-content-center align-items-center gap-3 mb-4">
+          <div>
+            <%= f.label :keyword, "キーワード" %>
+          </div>
+          <div class="w-50">
+            <%= f.text_field :keyword, value: params[:keyword], placeholder: "気になる言葉を入力してみよう", class: "form-control" %>
+          </div>
+          <div>
+            <%= f.submit "検索" , class: "btn btn-success" %> 
+          </div> 
+        </div>
+        <div>
+          <div class="container mb-2">
+            <h4>カテゴリー</h4>
+            <div class="d-flex flex-wrap gap-3 mb-4">
+              <% @genres.each do |genre| %>
+                <div class="form-check">
+                  <label class="form-check-label">
+                    <%= check_box_tag 'genre_ids[]', genre.id, params[:genre_ids]&.include?(genre.id.to_s), class: "form-check-input" %>
+                    <%= genre.name %>
+                  </label>
+                </div>
+              <% end %>
+            </div>
+            <div>
+              <h4>検索のヒント</h4>
+              <p>
+                気になるキーワード（糖尿病、認知症、健康、散歩、30代、70代、名前など）を入力して検索してみましょう。興味のある投稿や、同じ境遇の方とつながりやすくなります。※カテゴリーの選択は任意です。必要に応じて選択し、「検索」ボタンを押してください。
+              </p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div><%# search-form-area %>
+  </div><%# container bg-light rounded-3 py-5 px-4 align-items-center justify-content-between %>
+</div><%# w-50 mx-auto %>
+
+

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -7,24 +7,16 @@
 </nav> 
 
 <div class="card-list-container py-5">
-  <% @posts.each do |post| %>
-  <div class="card w-50 mx-auto mt-4">
-    <div class="card-header bg-white d-flex align-items-center">
-      <%= link_to member_path(post.member), class: "text-decoration-none link-dark d-flex align-items-center" do %>  
-        <%= image_tag post.member.get_profile_image(50, 50), alt: "プロフィール画像", class: "rounded-circle me-3" %> 
-        <span><%= post.member.name %></span>
-      <% end %> 
-    </div>
-    <%= image_tag post.get_image(600, 500), alt: "投稿画像", class: "card-img-top", style: "max-height: 500px; object-fit: cover;" %>
-    <div class="card-body">
-      <h4 class="card-title"><%= post.title %></h4>
-      <p class="card-text">投稿の内容:<%= post.genre.present? ? post.genre.name : "未選択" %></p>
-      <p class="card-text"><%= post.body %></p>
-    </div>
+  <%= render 'public/posts/search_form' %>
+  <div class="w-50 mx-auto mt-5">
+    <% if params[:keyword].present? || params[:genre_ids].present? %>
+      <h4>検索結果（<%= @posts.total_count %> 件）</h4>
+    <% else %>
+      <h4>新着投稿一覧</h4>
+    <% end %>
   </div>
-  <% end %>
-</div>
-
-<div class="d-flex justify-content-center mt-4">
-  <%= paginate @posts, theme: 'bootstrap-5' %>
+  <%= render 'public/posts/post_list', posts: @posts %>
+  <div class="d-flex justify-content-center mt-4">
+    <%= paginate @posts, theme: 'bootstrap-5' %>
+  </div>
 </div>


### PR DESCRIPTION
## 概要

投稿一覧に以下の検索機能を実装し、あわせて検索フォームおよび一覧レイアウトのデザイン調整を行いました。

---

## 実装内容

- 投稿のキーワード検索機能を追加（タイトル・本文・投稿者名に対して部分一致）
- ジャンル（カテゴリー）による複数選択検索を追加
- 検索条件に応じた見出し表示（「検索結果」「新着投稿一覧」）
- `includes(:genre, :member)` によるN+1問題の対策
- `joins(:member)` を用いて投稿者名での検索に対応
- カテゴリ選択用チェックボックスをフォームに追加

---

## 対象ファイル

- `posts_controller.rb`
- `views/public/posts/_search_form.html.erb`
- `views/public/posts/index.html.erb`
- `views/public/posts/_post_list.html.erb`

---

## 確認方法

1. 投稿一覧ページ `/posts` にアクセス
2. キーワード・カテゴリーいずれかまたは両方を指定して「検索」ボタンを押下
3. 条件に応じた投稿が一覧で表示され、検索条件に応じた件数が見出しに表示されることを確認
4. フォームや一覧が中央寄せ・適切な余白・背景色で表示されていることを確認

---

## 補足

- ジャンル選択は複数可とし、`genre_ids[]` をパラメータとして受け取る実装にしています
- 投稿者名の検索対応のため、`joins(:member)` を明示的に追加しています
