### PR TITLE
コメント機能を実装し、レイアウトを調整

### DIFF
--- a/app/assets/stylesheets/public/comments.scss
+++ b/app/assets/stylesheets/public/comments.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/comments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/public/comments_controller.rb
+++ b/app/controllers/public/comments_controller.rb
@@ -1,0 +1,22 @@
+class Public::CommentsController < ApplicationController
+  def create
+    post = Post.find(params[:post_id])
+    comment = current_member.comments.new(comment_params)
+    comment.post_id = post.id
+    comment.save
+    redirect_to post_path(post)
+  end
+
+  def destroy
+    comment = Comment.find(params[:id])
+    post = comment.post
+    comment.destroy
+    redirect_to post_path(post)
+  end
+  
+  private
+  
+  def comment_params
+    params.require(:comment).permit(:comment_body)
+  end
+end

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -36,6 +36,7 @@ class Public::PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
+    @comment = Comment.new
   end
 
   def followings_posts

--- a/app/helpers/public/comments_helper.rb
+++ b/app/helpers/public/comments_helper.rb
@@ -1,0 +1,2 @@
+module Public::CommentsHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :member
+  belongs_to :post
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -6,6 +6,7 @@ class Member < ApplicationRecord
 
   has_one_attached :profile_image, dependent: :destroy  
   has_many :posts, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   
   validates :name, presence: true, on: :update_profile

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,7 @@ class Post < ApplicationRecord
   belongs_to :member
   belongs_to :genre, optional: true
   has_one_attached :image, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   def get_image(width, height)
     unless image.attached?

--- a/app/views/public/comments/create.html.erb
+++ b/app/views/public/comments/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Public::Comments#create</h1>
+<p>Find me in app/views/public/comments/create.html.erb</p>

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -43,6 +43,7 @@
       <h4 class="card-title"><%= post.title %></h4>
       <p class="card-text">投稿の種類：<%= post.genre.present? ? post.genre.name : "未選択" %></p>
       <p class="card-text"><%= post.body %></p>
+      <%= link_to "続きを見る", post_path(post)%>
     </div>
   </div>
   <% end %>

--- a/app/views/public/posts/_post_list.html.erb
+++ b/app/views/public/posts/_post_list.html.erb
@@ -11,6 +11,7 @@
       <h4 class="card-title"><%= post.title %></h4>
       <p class="card-text">投稿の種類：<%= post.genre.present? ? post.genre.name : "未選択" %></p>
       <p class="card-text"><%= post.body %></p>
+      <%= link_to "続きを見る", post_path(post)%>
     </div>
   </div>
 <% end %>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -3,7 +3,7 @@
     <div class="card-header bg-white d-flex">
       <%= link_to member_path(@post.member), class: "text-decoration-none link-dark d-flex align-items-center" do %> 
          <%= image_tag @post.member.get_profile_image(50, 50), alt: "プロフィール画像", class: "rounded-circle me-3" %> 
-         <span><%= "#{@post.member.name}さんのマイページを見る" %></span>
+         <span><%= @post.member.name %></span>
       <% end %>
     </div>
     <%= image_tag @post.get_image(600,500), alt: "投稿画像", class: "card-img-top", style: "max-height: 500px; object-fit: cover;" %>
@@ -11,5 +11,25 @@
       <h4 class="card-title"><%= @post.title %></h4>
       <p class="card-text"><%= @post.body %></p>
     </div>
-  </div>
-</div>
+    <div>
+      <% @post.comments.each do |comment| %>
+        <%= link_to member_path(comment.member), class: "text-decoration-none link-dark d-flex align-items-center" do %>
+          <%= image_tag comment.member.get_profile_image(35,35), alt: "プロフィール画像", class: "rounded-circle me-3" %>
+          <span><%= comment.member.name %></span>
+        <% end %>
+        <%= comment.comment_body%>
+        <% if comment.member == current_member %>
+          <%= link_to "削除", post_comment_path(comment.post, comment), method: :delete, class: "btn btn-outline-danger" %>
+        <% end %>
+      <% end %>
+    </div>
+    <div>
+      <%= form_with model: [@post, @comment] do |f| %>
+        <%= f.text_area :comment_body, rows: '5', placeholder: "コメントをここに" %>
+        <%= f.submit "送信する" %>
+      <% end %>
+    </div><%# card-header bg-white d-flex %>
+  </div><%# card w-50 mx-auto mt-4 %>
+</div><%# card-list-container py-5 %>
+
+

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -11,25 +11,33 @@
       <h4 class="card-title"><%= @post.title %></h4>
       <p class="card-text"><%= @post.body %></p>
     </div>
-    <div>
-      <% @post.comments.each do |comment| %>
-        <%= link_to member_path(comment.member), class: "text-decoration-none link-dark d-flex align-items-center" do %>
-          <%= image_tag comment.member.get_profile_image(35,35), alt: "プロフィール画像", class: "rounded-circle me-3" %>
-          <span><%= comment.member.name %></span>
+    <div class="w-100 mx-auto">
+      <div class="container bg-light rounded-3 py-5 px-4 align-items-center justify-content-between">
+        <h5>コメントを書いて応援しましょう</h5>
+        <% @post.comments.each do |comment| %>
+          <div class="d-flex flex-column flex-md-row border-bottom align-items-start justify-content-between py-3 gap-2">
+            <div class="d-flex flex-column flex-md-row align-items-md-center w-100">
+              <%= link_to member_path(comment.member), class: "text-decoration-none link-dark d-flex align-items-center mb-2 mb-md-0 me-md-3" do %>
+                <%= image_tag comment.member.get_profile_image(35,35), alt: "プロフィール画像", class: "rounded-circle me-2" %>
+                <span class="text-nowrap"><%= comment.member.name %></span>
+              <% end %>
+              <p class="mb-0 ms-md-3 text-break"><%= comment.comment_body %></p>
+            </div>
+            <% if comment.member == current_member %>
+              <%= link_to "削除", post_comment_path(comment.post, comment), method: :delete, class: "btn btn-outline-danger btn-sm align-self-md-center text-nowrap" %>
+            <% end %>
+          </div>
         <% end %>
-        <%= comment.comment_body%>
-        <% if comment.member == current_member %>
-          <%= link_to "削除", post_comment_path(comment.post, comment), method: :delete, class: "btn btn-outline-danger" %>
+
+        <%= form_with model: [@post, @comment], local: true do |f| %>
+          <div class="mb-3 mt-4">
+            <%= f.text_area :comment_body, rows: 5, class: "form-control", placeholder: "コメントはこちらで入力できます" %>
+          </div>
+          <div class="text-center">
+            <%= f.submit "送信する", class: "btn btn-outline-primary" %>
+          </div>
         <% end %>
-      <% end %>
+      </div>
     </div>
-    <div>
-      <%= form_with model: [@post, @comment] do |f| %>
-        <%= f.text_area :comment_body, rows: '5', placeholder: "コメントをここに" %>
-        <%= f.submit "送信する" %>
-      <% end %>
-    </div><%# card-header bg-white d-flex %>
   </div><%# card w-50 mx-auto mt-4 %>
 </div><%# card-list-container py-5 %>
-
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,10 +32,12 @@ Rails.application.routes.draw do
         get :followings         
       end
     end
+
     resources :posts do
       collection do
         get :followings
       end
+      resources :comments, only: [:create, :destroy]
     end
   end
 end

--- a/db/migrate/20250617072923_create_comments.rb
+++ b/db/migrate/20250617072923_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.text :comment_body, null: false
+      t.references :member, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_16_111707) do
+ActiveRecord::Schema.define(version: 2025_06_17_072923) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -52,6 +52,16 @@ ActiveRecord::Schema.define(version: 2025_06_16_111707) do
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.text "comment_body", null: false
+    t.integer "member_id", null: false
+    t.integer "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["member_id"], name: "index_comments_on_member_id"
+    t.index ["post_id"], name: "index_comments_on_post_id"
+  end
+
   create_table "genres", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -84,5 +94,7 @@ ActiveRecord::Schema.define(version: 2025_06_16_111707) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "members"
+  add_foreign_key "comments", "posts"
   add_foreign_key "posts", "members"
 end

--- a/test/controllers/public/comments_controller_test.rb
+++ b/test/controllers/public/comments_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class Public::CommentsControllerTest < ActionDispatch::IntegrationTest
+  test "should get create" do
+    get public_comments_create_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  comment_body: MyText
+  member: one
+  post: one
+
+two:
+  comment_body: MyText
+  member: two
+  post: two

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
投稿詳細ページにコメント機能を追加しました。  
コメントの一覧表示・新規投稿を可能にし、レイアウトも整えました。

---

## 実装内容）
- `CommentsController#create` アクションの追加
- `CommentsController#destroy` アクションの追加
- `form_with` を使用したコメント投稿フォームを `posts/show.html.erb` に設置
- コメント一覧を同ページ内に表示（`@post.comments.each`）
- レイアウト調整（Bootstrap適用）
---
