### PR TITLE
Add: 投稿の保存機能を実装し、保存一覧画面と投稿カードのレイアウトを調整

### DIFF
--- a/app/assets/stylesheets/public/saved_posts.scss
+++ b/app/assets/stylesheets/public/saved_posts.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/saved_posts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/public/members_controller.rb
+++ b/app/controllers/public/members_controller.rb
@@ -23,6 +23,7 @@ class Public::MembersController < ApplicationController
   end
 
   def saved_posts
+    @saved_posts = current_member.saved_posts_posts.page(params[:page])
   end
 
   def followers

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -1,10 +1,11 @@
 class Public::PostsController < ApplicationController
-  before_action :is_matching_login_user, only: [:edit, :update]
   before_action :authenticate_member!
+  before_action :is_matching_login_user, only: [:edit, :update]
+  before_action :set_post, only: [:show, :edit, :update, :destroy, :is_matching_login_user]
+  before_action :set_genres, only: [:new, :edit, :create, :update, :show]
 
   def new
     @post = Post.new
-    @genres = Genre.all
   end
 
   def create
@@ -13,7 +14,6 @@ class Public::PostsController < ApplicationController
     if @post.save
       redirect_to member_path(current_member)
     else
-      @genres = Genre.all
       render :new
     end
   end
@@ -35,7 +35,6 @@ class Public::PostsController < ApplicationController
   end
 
   def show
-    @post = Post.find(params[:id])
     @comment = Comment.new
   end
 
@@ -43,22 +42,17 @@ class Public::PostsController < ApplicationController
   end
 
   def edit
-    @post = Post.find(params[:id])
-    @genres = Genre.all
   end
 
   def update
-    @post = Post.find(params[:id])
     if @post.update(post_params)
       redirect_to member_path(current_member)
     else
-      @genres = Genre.all
       render :edit
     end
   end
 
   def destroy
-    @post = Post.find(params[:id])
     if @post.destroy
       redirect_to member_path(current_member)
     else
@@ -68,14 +62,21 @@ class Public::PostsController < ApplicationController
 
   private
 
-  def post_params
-    params.require(:post).permit(:title, :image, :body, :genre_id)
-  end
-
   def is_matching_login_user
-    @post = Post.find(params[:id])
     unless @post.member == current_member
       redirect_to posts_path
     end
+  end
+
+  def set_post
+    @post = Post.find(params[:id])
+  end
+
+  def set_genres
+    @genres = Genre.all
+  end
+
+  def post_params
+    params.require(:post).permit(:title, :image, :body, :genre_id)
   end
 end

--- a/app/controllers/public/saved_posts_controller.rb
+++ b/app/controllers/public/saved_posts_controller.rb
@@ -1,0 +1,15 @@
+class Public::SavedPostsController < ApplicationController
+  def create
+    post = Post.find(params[:post_id])
+    saved_post = current_member.saved_posts.new(post_id: post.id)
+    saved_post.save
+    redirect_to post_path(post)
+  end
+
+  def destroy
+    post = Post.find(params[:post_id])
+    saved_post = current_member.saved_posts.find_by(post_id: post.id)
+    saved_post.destroy
+    redirect_to post_path(post)
+  end
+end

--- a/app/helpers/public/saved_posts_helper.rb
+++ b/app/helpers/public/saved_posts_helper.rb
@@ -1,0 +1,2 @@
+module Public::SavedPostsHelper
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -7,7 +7,8 @@ class Member < ApplicationRecord
   has_one_attached :profile_image, dependent: :destroy  
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
-
+  has_many :saved_posts, dependent: :destroy
+  has_many :saved_posts_posts, through: :saved_posts, source: :post
   
   validates :name, presence: true, on: :update_profile
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,6 +3,7 @@ class Post < ApplicationRecord
   belongs_to :genre, optional: true
   has_one_attached :image, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :saved_posts, dependent: :destroy
 
   def get_image(width, height)
     unless image.attached?
@@ -10,6 +11,10 @@ class Post < ApplicationRecord
       image.attach(io: File.open(file_path), filename: 'default-image.jpg', content_type: 'image/jpg') 
     end
     image.variant(resize_to_limit: [width, height]).processed
+  end
+
+  def saved_post_by?(member)
+    saved_posts.exists?(member_id: member.id)
   end
 
   validates :title,  presence: true

--- a/app/models/saved_post.rb
+++ b/app/models/saved_post.rb
@@ -1,0 +1,7 @@
+class SavedPost < ApplicationRecord
+  belongs_to :member
+  belongs_to :post
+
+  validates :member, uniqueness: {scope: :post_id}
+  
+end

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -13,7 +13,7 @@
   <% end %>
   
   <%= link_to saved_posts_path, class: "nav-link text-body" do %>
-    <i class="fa-regular fa-bookmark me-2"></i> お気に入り投稿一覧
+    <i class="fa-regular fa-bookmark me-2"></i> 保存した投稿一覧
   <% end %>
 
   <%= link_to "#", class: "nav-link text-body" do %><%# followings_member_path(current_member) %>

--- a/app/views/public/members/saved_posts.html.erb
+++ b/app/views/public/members/saved_posts.html.erb
@@ -1,2 +1,9 @@
-<h1>Public::Members#saved_posts</h1>
-<p>Find me in app/views/public/members/saved_posts.html.erb</p>
+<nav class="navbar border-bottom mt-4">
+  <div class="container w-50">
+    <div class="navbar-header mb-4">
+      <h2>保存した投稿一覧</h2>
+    </div>
+  </div>
+</nav> 
+
+<%= render 'public/posts/post_list', posts: @saved_posts %>

--- a/app/views/public/posts/_post_list.html.erb
+++ b/app/views/public/posts/_post_list.html.erb
@@ -1,4 +1,4 @@
-<% @posts.each do |post| %>
+<% posts.each do |post| %>
   <div class="card w-50 mx-auto mt-4">
     <div class="card-header bg-white d-flex align-items-center">
       <%= link_to member_path(post.member), class: "text-decoration-none link-dark d-flex align-items-center" do %>  

--- a/app/views/public/posts/_save_button.html.erb
+++ b/app/views/public/posts/_save_button.html.erb
@@ -1,0 +1,9 @@
+<% if @post.saved_post_by?(current_member) %>
+  <%= link_to post_saved_post_path(@post), method: :delete, class: "text-decoration-none link-dark" do %>
+    <i class="fa-solid fa-bookmark"></i>保存済み
+  <% end %>
+<% else %>
+  <%= link_to post_saved_post_path(@post), method: :post, class: "text-decoration-none link-dark" do %>
+    <i class="fa-regular fa-bookmark"></i>保存する
+  <% end %>
+<% end %>

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar border-bottom mt-4">
-  <div class="container">
+  <div class="container w-50">
     <div class="navbar-header mb-4">
       <h2>投稿を探す</h2>
     </div>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -1,14 +1,18 @@
 <div class="card-list-container py-5">
   <div class="card w-50 mx-auto mt-4">
-    <div class="card-header bg-white d-flex">
-      <%= link_to member_path(@post.member), class: "text-decoration-none link-dark d-flex align-items-center" do %> 
-         <%= image_tag @post.member.get_profile_image(50, 50), alt: "プロフィール画像", class: "rounded-circle me-3" %> 
-         <span><%= @post.member.name %></span>
-      <% end %>
+    <div class="card-header bg-white d-flex justify-content-between align-items-center">
+      <div class="d-flex align-items-center">
+        <%= link_to member_path(@post.member), class: "text-decoration-none link-dark d-flex align-items-center" do %> 
+           <%= image_tag @post.member.get_profile_image(50, 50), alt: "プロフィール画像", class: "rounded-circle me-3" %> 
+           <span><%= @post.member.name %></span>
+        <% end %>
+      </div>
+      <div><%= render 'public/posts/save_button', post: @post %></div>
     </div>
     <%= image_tag @post.get_image(600,500), alt: "投稿画像", class: "card-img-top", style: "max-height: 500px; object-fit: cover;" %>
     <div class="card-body">
       <h4 class="card-title"><%= @post.title %></h4>
+      <p class="card-text">投稿の種類：<%= @post.genre.present? ? @post.genre.name : "未選択" %></p>
       <p class="card-text"><%= @post.body %></p>
     </div>
     <div class="w-100 mx-auto">
@@ -37,7 +41,7 @@
             <%= f.submit "送信する", class: "btn btn-outline-primary" %>
           </div>
         <% end %>
-      </div>
-    </div>
+      </div><%# container bg-light rounded-3 py-5 px-4 align-items-center justify-content-between %>
+    </div><%# w-100 mx-auto %>
   </div><%# card w-50 mx-auto mt-4 %>
 </div><%# card-list-container py-5 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
         get :followings
       end
       resources :comments, only: [:create, :destroy]
+      resource :saved_post, only: [:create, :destroy]
     end
   end
 end

--- a/db/migrate/20250618012623_create_saved_posts.rb
+++ b/db/migrate/20250618012623_create_saved_posts.rb
@@ -1,0 +1,10 @@
+class CreateSavedPosts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :saved_posts do |t|
+      t.references :member, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_17_072923) do
+ActiveRecord::Schema.define(version: 2025_06_18_012623) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -92,9 +92,20 @@ ActiveRecord::Schema.define(version: 2025_06_17_072923) do
     t.index ["member_id"], name: "index_posts_on_member_id"
   end
 
+  create_table "saved_posts", force: :cascade do |t|
+    t.integer "member_id", null: false
+    t.integer "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["member_id"], name: "index_saved_posts_on_member_id"
+    t.index ["post_id"], name: "index_saved_posts_on_post_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "members"
   add_foreign_key "comments", "posts"
   add_foreign_key "posts", "members"
+  add_foreign_key "saved_posts", "members"
+  add_foreign_key "saved_posts", "posts"
 end

--- a/test/controllers/public/saved_posts_controller_test.rb
+++ b/test/controllers/public/saved_posts_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Public::SavedPostsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/saved_posts.yml
+++ b/test/fixtures/saved_posts.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  member: one
+  post: one
+
+two:
+  member: two
+  post: two

--- a/test/models/saved_post_test.rb
+++ b/test/models/saved_post_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SavedPostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
##  概要
投稿に「保存機能」を追加し、ユーザーが後で見返したい投稿を記録できるようにしました。  
あわせて、保存一覧画面と投稿カードのレイアウト調整も実施しました。

---

## 実装内容

### 🔧 モデル関連
- `SavedPost` モデルを作成（中間テーブル：`member_id` × `post_id`）
- バリデーション：同一投稿を重複保存できないよう `uniqueness` を追加

### 🔧 アソシエーション
- `Member` モデルに `has_many :saved_posts` / `has_many :saved_posts_posts, through: :saved_posts, source: :post` を追加
- `Post` モデルに `has_many :saved_posts`、および `saved_by?(member)` メソッドを追加

###  画面/UI
- 投稿詳細画面に「💾 保存する / 保存済み」ボタンを表示（右上）
- ボタンはログインユーザーのみに表示・保存状態で切り替え
- 保存ボタン用の部分テンプレート `_save_button.html.erb` を作成
- 保存済み投稿一覧画面 `members/saved_posts` を追加し、`_post_list.html.erb` を再利用

