### PR TITLE
フォロー・フォロワー機能の表示＆レイアウト実装

### DIFF
--- a/app/assets/stylesheets/public/relationships.scss
+++ b/app/assets/stylesheets/public/relationships.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/relationships controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/public/members_controller.rb
+++ b/app/controllers/public/members_controller.rb
@@ -26,10 +26,14 @@ class Public::MembersController < ApplicationController
     @saved_posts = current_member.saved_posts_posts.page(params[:page])
   end
 
-  def followers
+  def followings
+    member = Member.find(params[:id])
+    @followings = member.followings.page(params[:page]).per(15)
   end
 
-  def followings
+  def followers
+    mamber = Member.find(params[:id])
+    @followers = mamber.followers.page(params[:page]).per(15)
   end
 
   private

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -39,7 +39,7 @@ class Public::PostsController < ApplicationController
   end
 
   def followings
-    following_ids = crrent_member.following_ids
+    following_ids = current_member.following_ids
     @posts = Post.where(member_id: following_ids).includes(:member, :genre).order(created_at: :desc).page(params[:page])
   end
 

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -38,7 +38,9 @@ class Public::PostsController < ApplicationController
     @comment = Comment.new
   end
 
-  def followings_posts
+  def followings
+    following_ids = crrent_member.following_ids
+    @posts = Post.where(member_id: following_ids).includes(:member, :genre).order(created_at: :desc).page(params[:page])
   end
 
   def edit

--- a/app/controllers/public/relationships_controller.rb
+++ b/app/controllers/public/relationships_controller.rb
@@ -1,0 +1,14 @@
+class Public::RelationshipsController < ApplicationController
+  before_action :authenticate_member!
+  def create
+    member =  Member.find(params[:member_id])
+    current_member.follow(member)
+    redirect_to member_path(member)
+  end
+
+  def destroy
+    member = Member.find(params[:member_id])
+    current_member.unfollow(member)
+    redirect_to member_path(member)
+  end
+end

--- a/app/helpers/public/relationships_helper.rb
+++ b/app/helpers/public/relationships_helper.rb
@@ -1,0 +1,2 @@
+module Public::RelationshipsHelper
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -9,6 +9,10 @@ class Member < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :saved_posts, dependent: :destroy
   has_many :saved_posts_posts, through: :saved_posts, source: :post
+  has_many :active_relationships, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
+  has_many :passive_relationships, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
+  has_many :followings, through: :active_relationships, source: :followed
+  has_many :followers, through: :passive_relationships,source: :follower
   
   validates :name, presence: true, on: :update_profile
 
@@ -20,4 +24,15 @@ class Member < ApplicationRecord
     profile_image.variant(resize_to_limit: [width, height]).processed
   end
 
+  def follow(member)
+    active_relationships.create(followed_id: member.id)
+  end
+
+  def unfollow(member)
+    active_relationships.find_by(followed_id: member.id).destroy
+  end
+
+  def following?(member)
+    followings.include?(member)
+  end
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,4 @@
+class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: "Member"
+  belongs_to :followed, class_name: "Member"
+end

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -16,7 +16,7 @@
     <i class="fa-regular fa-bookmark me-2"></i> 保存した投稿一覧
   <% end %>
 
-  <%= link_to "#", class: "nav-link text-body" do %><%# followings_member_path(current_member) %>
+  <%= link_to followings_posts_path, class: "nav-link text-body" do %>
     <i class="fa-regular fa-thumbs-up me-2"></i> 応援している人の投稿一覧
   <% end %>
 

--- a/app/views/public/members/edit_profile.html.erb
+++ b/app/views/public/members/edit_profile.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar border-bottom mt-4">
-  <div class="container">
+  <div class="containe w-50">
     <div class="navbar-header mb-4">
       <h2>マイページを編集する</h2>
     </div>

--- a/app/views/public/members/followers.html.erb
+++ b/app/views/public/members/followers.html.erb
@@ -1,2 +1,28 @@
-<h1>Public::Members#followers</h1>
-<p>Find me in app/views/public/members/followers.html.erb</p>
+<nav class="navbar border-bottom mt-4">
+  <div class="container w-50">
+    <div class="navbar-header mb-4">
+      <h2>応援されている人の一覧</h2>
+    </div>
+  </div>
+</nav>  
+
+<div class="container w-50 followers-page mt-2">
+  <div class="list-group">
+    <% @followers.each do |member| %>
+      <div class="d-flex justify-content-between align-items-center border-bottom py-3">
+        <div class="d-flex align-items-center">
+          <%= link_to member_path(member), class: "text-decoration-none link-dark d-flex align-items-center" do %>  
+            <%= image_tag member.get_profile_image(40,40), class: "rounded-circle me-2" %>
+            <span><%= member.name %></span>
+          <% end %> 
+        </div>
+        <%= link_to "削除", member_relationship_path(member), method: :delete, class: "btn btn-outline-danger btn-sm" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="d-flex justify-content-center mt-4">
+    <%= paginate @followers, theme: 'bootstrap-5' %>
+  </div>
+
+</div>

--- a/app/views/public/members/followings.html.erb
+++ b/app/views/public/members/followings.html.erb
@@ -1,2 +1,28 @@
-<h1>Public::Members#followings</h1>
-<p>Find me in app/views/public/members/followings.html.erb</p>
+<nav class="navbar border-bottom mt-4">
+  <div class="container w-50">
+    <div class="navbar-header mb-4">
+      <h2>応援している人の一覧</h2>
+    </div>
+  </div>
+</nav>  
+
+<div class="container w-50 followings-page mt-2">
+  <div class="list-group">
+    <% @followings.each do |member| %>
+      <div class="d-flex justify-content-between align-items-center border-bottom py-3">
+        <div class="d-flex align-items-center">
+          <%= link_to member_path(member), class: "text-decoration-none link-dark d-flex align-items-center" do %>  
+            <%= image_tag member.get_profile_image(40,40), class: "rounded-circle me-2" %>
+            <span><%= member.name %></span>
+          <% end %> 
+        </div>
+        <%= link_to "削除", member_relationship_path(member), method: :delete, class: "btn btn-outline-danger btn-sm" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="d-flex justify-content-center mt-4">
+    <%= paginate @followings, theme: 'bootstrap-5' %>
+  </div>
+
+</div>

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -6,6 +6,15 @@
       </div>
       <div class="col-md-10">
         <h3><%= @member.name %></h3>
+        <div>
+          <% if current_member != @member %>
+            <% if current_member.following?(@member) %>
+              <%= link_to '応援をやめる', member_relationship_path(@member.id), method: :delete, class: "btn-sm btn-danger" %>
+            <% else %>
+              <%= link_to '応援する', member_relationship_path(@member.id), method: :post, class: "btn-sm btn-success" %>
+            <% end %>
+          <% end %>
+        </div>
         <p><%= @member.self_introduction %></p>
         <% if current_member == @member %> 
           <%= link_to edit_member_registration_path, class: "text-dark me-4 d-inline-block" do %>
@@ -15,10 +24,10 @@
             <span><i class="fa-solid fa-file-pen"></i> マイページ編集</span>
           <% end %>
         <% end %>
-        <%= link_to "#", class: "text-dark me-4 d-inline-block" do %>
+        <%= link_to followings_member_path(current_member), class: "text-dark me-4 d-inline-block" do %>
           <span><i class="fa-solid fa-handshake-simple"></i> 応援している人一覧</span>
         <% end %>
-        <%= link_to "#", class: "text-dark me-4 d-inline-block" do %>
+        <%= link_to followers_member_path(current_member), class: "text-dark me-4 d-inline-block" do %>
           <span><i class="fa-solid fa-hand-holding-heart"></i> 応援されている人一覧</span>
         <% end %>
       </div>

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -1,38 +1,40 @@
 <nav class="navbar border-bottom mt-4">
-  <div class="w-75 container">
-    <div class="row align-items-center">
+  <div class="w-50 container">
+    <div class="row align-items-center mb-4">
       <div class="col-md-2">
-        <%= image_tag @member.get_profile_image(100,100) %>
+        <%= image_tag @member.get_profile_image(100,100), class: "rounded-circle me-3" %>
       </div>
       <div class="col-md-10">
         <h3><%= @member.name %></h3>
-        <div>
-          <% if current_member != @member %>
-            <% if current_member.following?(@member) %>
-              <%= link_to '応援をやめる', member_relationship_path(@member.id), method: :delete, class: "btn-sm btn-danger" %>
-            <% else %>
-              <%= link_to '応援する', member_relationship_path(@member.id), method: :post, class: "btn-sm btn-success" %>
-            <% end %>
-          <% end %>
-        </div>
         <p><%= @member.self_introduction %></p>
         <% if current_member == @member %> 
-          <%= link_to edit_member_registration_path, class: "text-dark me-4 d-inline-block" do %>
+          <%= link_to edit_member_registration_path, class: "text-dark me-4 text-decoration-none" do %>
             <span><i class="fa-solid fa-user-gear"></i> 個人情報編集</span>
           <% end %>
-          <%= link_to edit_profile_path, class: "text-dark me-4 d-inline-block" do %>
+          <%= link_to edit_profile_path, class: "text-dark me-4 text-decoration-none" do %>
             <span><i class="fa-solid fa-file-pen"></i> マイページ編集</span>
           <% end %>
         <% end %>
-        <%= link_to followings_member_path(current_member), class: "text-dark me-4 d-inline-block" do %>
+        <%= link_to followings_member_path(current_member), class: "text-dark me-4 text-decoration-none" do %>
           <span><i class="fa-solid fa-handshake-simple"></i> 応援している人一覧</span>
         <% end %>
-        <%= link_to followers_member_path(current_member), class: "text-dark me-4 d-inline-block" do %>
+        <%= link_to followers_member_path(current_member), class: "text-dark me-4 text-decoration-none" do %>
           <span><i class="fa-solid fa-hand-holding-heart"></i> 応援されている人一覧</span>
         <% end %>
+        <% if current_member != @member %>
+          <% if current_member.following?(@member) %>
+            <%= link_to member_relationship_path(@member.id), method: :delete, class: "text-dark me-4 text-decoration-none" do %>
+              <span><i class="fa-solid fa-thumbs-up"></i>応援をやめる</span>
+            <% end %>
+          <% else %>
+            <%= link_to member_relationship_path(@member.id), method: :post, class: "text-dark me-4 text-decoration-none" do %>
+              <span><i class="fa-regular fa-thumbs-up"></i>応援をする</span>
+            <% end %>
+          <% end %>
+        <% end %>
       </div>
-    </div><%# row align-items-center %>
-  </div><%# w-75 container %>
+    </div><%# row align-items-center mb-4 %>
+  </div><%# w-50 container %>
 </nav><%# navbar border-bottom mt-4 %>
 
 <div class="card-list-container py-5">

--- a/app/views/public/posts/followings.html.erb
+++ b/app/views/public/posts/followings.html.erb
@@ -1,0 +1,13 @@
+<nav class="navbar border-bottom mt-4">
+  <div class="container w-50">
+    <div class="navbar-header mb-4">
+      <h2>応援している人の投稿一覧</h2>
+    </div>
+  </div>
+</nav> 
+
+<%= render 'public/posts/post_list', posts: @posts %>
+
+<div class="d-flex justify-content-center mt-4">
+  <%= paginate @posts, theme: 'bootstrap-5' %>
+</div>

--- a/app/views/public/posts/followings_posts.html.erb
+++ b/app/views/public/posts/followings_posts.html.erb
@@ -1,2 +1,0 @@
-<h1>Public::Posts#followings_posts</h1>
-<p>Find me in app/views/public/posts/followings_posts.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
         get :followers          
         get :followings         
       end
+      resource :relationship, only: [:create, :destroy]
     end
 
     resources :posts do

--- a/db/migrate/20250618053113_create_relationships.rb
+++ b/db/migrate/20250618053113_create_relationships.rb
@@ -1,0 +1,10 @@
+class CreateRelationships < ActiveRecord::Migration[6.1]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id, null: false
+      t.integer :followed_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_18_012623) do
+ActiveRecord::Schema.define(version: 2025_06_18_053113) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2025_06_18_012623) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -90,6 +90,13 @@ ActiveRecord::Schema.define(version: 2025_06_18_012623) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "genre_id"
     t.index ["member_id"], name: "index_posts_on_member_id"
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id", null: false
+    t.integer "followed_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "saved_posts", force: :cascade do |t|

--- a/test/controllers/public/relationships_controller_test.rb
+++ b/test/controllers/public/relationships_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Public::RelationshipsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  follower_id: 1
+  followed_id: 1
+
+two:
+  follower_id: 1
+  followed_id: 1

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
###  概要  
フォロー・フォロワー機能に関する以下の表示・UI部分の実装を行いました。

- フォロー／フォロワー一覧ページの作成（`followings.html.erb`, `followers.html.erb`）
- マイページ（`show.html.erb`）でのフォロー／フォロワー表示リンクの追加
- `RelationshipsController`による応援（フォロー）／応援解除（アンフォロー）の処理
- フォローしている人の投稿一覧画面、機能の追加

---

### 🛠 主な変更点

| ファイル名 | 内容 |
|------------|------|
| `routes.rb` | `relationship`リソースと`followings`, `followers`ルートの追加 |
| `members/show.html.erb` | 応援ボタン・応援者一覧リンクの追加 |
| `members_controller.rb` | `followings`, `followers`アクション追加 |
| `posts_controller.rb` | `followings`アクション追加（フォロー中メンバーの投稿一覧） |
| `followings.html.erb` | 応援している人の一覧を表示（リンク＋画像付き） |
| `followers.html.erb` | 応援されている人の一覧を表示（リンク＋画像付き） |
| `relationship.rb` | `belongs_to`設定（follower / followed） |
| `relationships_controller.rb` | フォロー・アンフォローの処理実装 |
| `member.rb` | 関連付け（active_relationships / passive_relationships）とフォロー用メソッド追加 |

---

