### PR TITLE
Feature/add notifications system

### DIFF
--- a/app/assets/stylesheets/public/notifications.scss
+++ b/app/assets/stylesheets/public/notifications.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/notifications controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/public/comments_controller.rb
+++ b/app/controllers/public/comments_controller.rb
@@ -1,10 +1,14 @@
 class Public::CommentsController < ApplicationController
   def create
-    post = Post.find(params[:post_id])
-    comment = current_member.comments.new(comment_params)
-    comment.post_id = post.id
-    comment.save
-    redirect_to post_path(post)
+    @post = Post.find(params[:post_id])
+    @comment = current_member.comments.new(comment_params.merge(post_id: @post.id))
+    if @comment.save
+      @post.create_notification_comment!(current_member, @comment.id)
+      redirect_to post_path(@post) 
+    else
+      flash.now[:alert] = "コメントの投稿に失敗しました"
+      render 'public/posts/show'
+    end
   end
 
   def destroy

--- a/app/controllers/public/notifications_controller.rb
+++ b/app/controllers/public/notifications_controller.rb
@@ -1,0 +1,8 @@
+class Public::NotificationsController < ApplicationController
+  def index
+    @notifications = current_member.passive_notifications.includes(:visitor, :post, :comment).page(params[:page]).per(15)
+    @notifications.where(checked: false).each do |notification|
+      notification.update(checked: true)
+    end    
+  end
+end

--- a/app/controllers/public/relationships_controller.rb
+++ b/app/controllers/public/relationships_controller.rb
@@ -3,6 +3,7 @@ class Public::RelationshipsController < ApplicationController
   def create
     member =  Member.find(params[:member_id])
     current_member.follow(member)
+    member.create_notification_follow!(current_member)
     redirect_to member_path(member)
   end
 

--- a/app/helpers/public/notifications_helper.rb
+++ b/app/helpers/public/notifications_helper.rb
@@ -1,0 +1,2 @@
+module Public::NotificationsHelper
+end

--- a/app/helpers/public/notifications_helper.rb
+++ b/app/helpers/public/notifications_helper.rb
@@ -1,2 +1,5 @@
 module Public::NotificationsHelper
+  def unchecked_notifications
+    current_member.passive_notifications.where(checked: false)
+  end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -13,3 +13,14 @@
 input[type="radio"] {
     accent-color: #198754;
 }
+
+.n-circle {
+    font-size: 0.4em;               
+    color: #efa04c;                 
+    left: -0.3em;                   
+    z-index: 10;
+  }
+
+.n-bell {
+    left: -0.3em;
+}

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -13,6 +13,9 @@ class Member < ApplicationRecord
   has_many :passive_relationships, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
   has_many :followings, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships,source: :follower
+  has_many :active_notifications, class_name: 'Notification', foreign_key: 'visitor_id', dependent: :destroy
+  has_many :passive_notifications, class_name: 'Notification', foreign_key: 'visited_id', dependent: :destroy
+
   
   validates :name, presence: true, on: :update_profile
 
@@ -34,5 +37,17 @@ class Member < ApplicationRecord
 
   def following?(member)
     followings.include?(member)
+  end
+
+  def create_notification_follow!(current_member)
+    # 既にフォロー通知が存在しない場合のみ、新規通知を作成
+    temp = Notification.where(["visitor_id = ? and visited_id = ? and action = ? ",current_member.id, id, 'follow'])
+    if temp.blank?
+      notification = current_member.active_notifications.new(
+        visited_id: id,
+        action: 'follow'
+      )
+      notification.save if notification.valid?
+    end
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,9 @@
+class Notification < ApplicationRecord
+  default_scope -> { order(created_at: :desc) }
+  belongs_to :post, optional: true
+  belongs_to :comment, optional: true
+  	
+  belongs_to :visitor, class_name: 'Member', foreign_key: 'visitor_id', optional: true
+  belongs_to :visited, class_name: 'Member', foreign_key: 'visited_id', optional: true
+
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,6 +4,7 @@ class Post < ApplicationRecord
   has_one_attached :image, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :saved_posts, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   def get_image(width, height)
     unless image.attached?
@@ -16,6 +17,28 @@ class Post < ApplicationRecord
   def saved_post_by?(member)
     saved_posts.exists?(member_id: member.id)
   end
+
+  def create_notification_comment!(current_member, comment_id)
+    temp_ids = Comment.select(:member_id).where(post_id: id).where.not(member_id: current_member.id).distinct
+    temp_ids.each do |temp_id|
+      save_notification_comment!(current_member, comment_id, temp_id['member_id'])
+    end
+    save_notification_comment!(current_member, comment_id, member_id) if temp_ids.blank?
+  end
+
+  def save_notification_comment!(current_member, comment_id, visited_id)
+    notification = current_member.active_notifications.new(
+      post_id: id,
+      comment_id: comment_id,
+      visited_id: visited_id,
+      action: 'comment'
+    )
+    if notification.visitor_id == notification.visited_id
+      notification.checked = true
+    end
+    notification.save if notification.valid?
+  end
+
 
   validates :title,  presence: true
   validates :body, presence: true

--- a/app/views/layouts/_notification_icon.html.erb
+++ b/app/views/layouts/_notification_icon.html.erb
@@ -1,0 +1,12 @@
+<%= link_to notifications_path, class: "nav-link text-body" do %>
+  <% if unchecked_notifications.any? %>
+    <span class="fa-stack me-2 style="position: relative;"">
+      <i class="fa-regular fa-bell n-bell fa-stack-1x"></i>
+      <i class="fa-solid fa-circle n-circle fa-stack-0.5x"></i>
+    </span>
+  <% else %>
+    <i class="fa-regular fa-bell me-2"></i>
+  <% end %>
+  通知一覧
+<% end %>
+

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -24,9 +24,7 @@
     <i class="fa-solid fa-magnifying-glass me-2"></i> 気になる投稿を検索
   <% end %>
 
-  <%= link_to notifications_path, class: "nav-link text-body" do %>
-    <i class="fa-regular fa-bell me-2"></i> 通知一覧
-  <% end %>
+  <%= render 'layouts/notification_icon' %>
 
   <%= link_to member_path(current_member), class: "nav-link text-body" do %>
     <i class="fa-regular fa-user me-2"></i> マイページ

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -24,7 +24,7 @@
     <i class="fa-solid fa-magnifying-glass me-2"></i> 気になる投稿を検索
   <% end %>
 
-  <%= link_to "#", class: "nav-link text-body" do %>
+  <%= link_to notifications_path, class: "nav-link text-body" do %>
     <i class="fa-regular fa-bell me-2"></i> 通知一覧
   <% end %>
 

--- a/app/views/public/members/edit_profile.html.erb
+++ b/app/views/public/members/edit_profile.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar border-bottom mt-4">
-  <div class="containe w-50">
+  <div class="container">
     <div class="navbar-header mb-4">
       <h2>マイページを編集する</h2>
     </div>

--- a/app/views/public/notifications/_notifications.html.erb
+++ b/app/views/public/notifications/_notifications.html.erb
@@ -1,0 +1,37 @@
+<% visitor = notification.visitor %>
+<% visited = notification.visited %>
+
+<div class="container w-50 notifications-page mt-2">
+  <div class="list-group">
+    <span>
+      <%= link_to member_path(visitor) do %>
+        <%= image_tag visitor.get_profile_image(40,40), class: "rounded-circle me-2" %>
+        <strong><%= visitor.name %></strong>
+      <% end %>
+        さんが
+      <% if notification.action == 'follow' %>
+        あなたをフォローしました
+      <% elsif notification.action == 'comment' %>
+        <% if notification.post.member_id == visited.id %>
+          <%= link_to 'あなたの投稿', notification.post, style: "font-weight: bold;" %>
+        <% else %>
+          <span>
+            <%= link_to post_path(notification.post) do %>
+              <%= image_tag visitor.get_profile_image(40,40), class: "rounded-circle me-2" %>
+              <strong><%= notification.post.member.name %>さんの投稿</strong>
+            <% end %>
+          </span>
+        <% end %>
+        にコメントしました
+        <p class="text-muted mb-0">
+          <%= Comment.find_by(id: notification.comment_id)&.comment_body %>
+        </p>
+      <% end %>
+    </span>
+  </div>
+
+  <div class="small text-muted text-right">
+    <%= time_ago_in_words(notification.created_at).upcase %>
+  </div>
+  <hr>
+</div>

--- a/app/views/public/notifications/index.html.erb
+++ b/app/views/public/notifications/index.html.erb
@@ -1,0 +1,18 @@
+<nav class="navbar border-bottom mt-4">
+  <div class="containe w-50">
+    <div class="navbar-header mb-4">
+      <h2>通知一覧</h2>
+    </div>
+  </div>
+</nav>  
+
+<% notifications = @notifications.where.not(visitor_id: current_member.id) %>
+<% if notifications.exists? %>
+  <%= render partial: 'public/notifications/notifications', collection: notifications, as: :notification %>
+  <div class="d-flex justify-content-center mt-4">
+    <%= paginate @notifications, theme: 'bootstrap-5' %>
+  </div>
+<% else %>
+  <p>通知はありません</p>
+<% end %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
       resource :relationship, only: [:create, :destroy]
     end
 
+    resources :notifications, only: :index
+
     resources :posts do
       collection do
         get :followings

--- a/db/migrate/20250620012353_create_notifications.rb
+++ b/db/migrate/20250620012353_create_notifications.rb
@@ -1,0 +1,19 @@
+class CreateNotifications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :notifications do |t|
+      t.integer :visitor_id, null: false
+      t.integer :visited_id, null: false
+      t.integer :post_id
+      t.integer :comment_id
+      t.string :action, default: '', null: false
+      t.boolean :checked, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index :notifications, :visitor_id
+    add_index :notifications, :visited_id
+    add_index :notifications, :post_id
+    add_index :notifications, :comment_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_18_053113) do
+ActiveRecord::Schema.define(version: 2025_06_20_012353) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -80,6 +80,21 @@ ActiveRecord::Schema.define(version: 2025_06_18_053113) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_members_on_email", unique: true
     t.index ["reset_password_token"], name: "index_members_on_reset_password_token", unique: true
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.integer "visitor_id", null: false
+    t.integer "visited_id", null: false
+    t.integer "post_id"
+    t.integer "comment_id"
+    t.string "action", default: "", null: false
+    t.boolean "checked", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["comment_id"], name: "index_notifications_on_comment_id"
+    t.index ["post_id"], name: "index_notifications_on_post_id"
+    t.index ["visited_id"], name: "index_notifications_on_visited_id"
+    t.index ["visitor_id"], name: "index_notifications_on_visitor_id"
   end
 
   create_table "posts", force: :cascade do |t|

--- a/test/controllers/public/notifications_controller_test.rb
+++ b/test/controllers/public/notifications_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Public::NotificationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
##  通知機能（コメント・フォロー）の表示＆既読処理のレイアウト実装（部分完了）

### 実装内容

- `NotificationsController#index`  
  - 通知の一覧を取得し、未読の通知を既読（`checked: true`）に更新
  - ページネーションを導入（15件/ページ）

- `Post`モデル  
  - コメント時に対象ユーザーへ通知を作成する `create_notification_comment!` メソッドを実装  
  - 通知先がコメント投稿者自身であれば、通知は既読済みに

- `Member`モデル  
  - フォロー時に通知を作成する `create_notification_follow!` を実装  
  - 二重通知防止のため、同一のフォロー通知が存在しないことを確認

- `CommentsController#create`  
  - コメント作成時に通知を作成する処理を追加（Postモデルのメソッド呼び出し）

- ビューファイルの実装  
  - `notifications/index.html.erb`：通知一覧の表示、未読の通知バッジ表示
  - `_notifications.html.erb`：通知ごとの表示レイアウト（フォロー or コメントに応じて分岐）
  - `_notification_icon.html.erb`：ヘッダーの通知アイコン横に未読通知がある場合はバッジを表示

