### PR TITLE
Add: フォロー・フォロワーの非同期処理を実装（Ajax対応）

### DIFF
--- a/app/controllers/public/relationships_controller.rb
+++ b/app/controllers/public/relationships_controller.rb
@@ -3,15 +3,13 @@ class Public::RelationshipsController < ApplicationController
   before_action :ensure_guest_member
 
   def create
-    member =  Member.find(params[:member_id])
-    current_member.follow(member)
-    member.create_notification_follow!(current_member)
-    redirect_to member_path(member)
+    @member =  Member.find(params[:member_id])
+    current_member.follow(@member)
+    @member.create_notification_follow!(current_member)
   end
 
   def destroy
-    member = Member.find(params[:member_id])
-    current_member.unfollow(member)
-    redirect_to member_path(member)
+    @member = Member.find(params[:member_id])
+    current_member.unfollow(@member)
   end
 end

--- a/app/controllers/public/saved_posts_controller.rb
+++ b/app/controllers/public/saved_posts_controller.rb
@@ -5,13 +5,11 @@ class Public::SavedPostsController < ApplicationController
     @post = Post.find(params[:post_id])
     saved_post = current_member.saved_posts.new(post_id: @post.id)
     saved_post.save
-    # redirect_to post_path(post)
   end
 
   def destroy
     @post = Post.find(params[:post_id])
     saved_post = current_member.saved_posts.find_by(post_id: @post.id)
     saved_post.destroy
-    # redirect_to post_path(post)
   end
 end

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar border-bottom mt-4">
-  <div class="w-50 container">
+  <div class="w-75 container">
     <div class="row align-items-center mb-4">
       <div class="col-md-2">
         <%= image_tag @member.get_profile_image(100,100), class: "rounded-circle me-3" %>
@@ -21,20 +21,12 @@
         <%= link_to followers_member_path(current_member), class: "text-dark me-4 text-decoration-none" do %>
           <span><i class="fa-solid fa-hand-holding-heart"></i> 応援されている人一覧</span>
         <% end %>
-        <% if current_member != @member %>
-          <% if current_member.following?(@member) %>
-            <%= link_to member_relationship_path(@member.id), method: :delete, class: "text-dark me-4 text-decoration-none" do %>
-              <span><i class="fa-solid fa-thumbs-up"></i>応援をやめる</span>
-            <% end %>
-          <% else %>
-            <%= link_to member_relationship_path(@member.id), method: :post, class: "text-dark me-4 text-decoration-none" do %>
-              <span><i class="fa-regular fa-thumbs-up"></i>応援をする</span>
-            <% end %>
-          <% end %>
-        <% end %>
+        <div id="relastionships-btn-<%= @member.id %>">  
+          <%= render 'public/relationships/follow_btn', member: @member %>
+        </div>
       </div>
     </div><%# row align-items-center mb-4 %>
-  </div><%# w-50 container %>
+  </div><%# w-75 container %>
 </nav><%# navbar border-bottom mt-4 %>
 
 <div class="card-list-container py-5">

--- a/app/views/public/relationships/_follow_btn.html.erb
+++ b/app/views/public/relationships/_follow_btn.html.erb
@@ -1,0 +1,11 @@
+<% if current_member != @member %>
+  <% if current_member.following?(@member) %>
+    <%= link_to member_relationship_path(@member.id), method: :delete, remote: true, class: "text-dark me-4 text-decoration-none" do %>
+      <span><i class="fa-solid fa-thumbs-up"></i>応援をやめる</span> 
+    <% end %>
+  <% else %>
+    <%= link_to member_relationship_path(@member.id), method: :post, remote: true, class: "text-dark me-4 text-decoration-none" do %>
+      <span><i class="fa-regular fa-thumbs-up"></i>応援をする</span>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/public/relationships/create.js.erb
+++ b/app/views/public/relationships/create.js.erb
@@ -1,0 +1,1 @@
+$("#relastionships-btn-<%= @member.id %>").html("<%= j(render 'public/relationships/follow_btn', member: @member) %>");

--- a/app/views/public/relationships/destroy.js.erb
+++ b/app/views/public/relationships/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#relastionships-btn-<%= @member.id %>").html("<%= j(render 'public/relationships/follow_btn', member: @member) %>");


### PR DESCRIPTION
## フォロー機能の非同期化を実装

### 概要
- フォローボタン／フォロー解除ボタンを非同期化
- Ajaxによりページ遷移なしでフォロー状態を即時反映
- UX（ユーザー体験）の向上を目的とした改善

### 変更点
- `create.js.erb` / `destroy.js.erb` を作成し、DOMの部分更新を実装
- JavaScriptにより、対象要素を `id="relationships-btn-#{member.id}"` で特定・置換
- ボタンのHTMLを `_follow_btn.html.erb`（部分テンプレート）に切り出し、再描画に対応

### 動作確認手順
1. ユーザー詳細画面でフォローボタンをクリック
2. ボタン表示が「応援する」⇄「応援をやめる」に即時切り替わる
3. ページリロードなしで状態が反映される（非同期通信）