### PR TITLE
Add: 管理者側にメンバー一覧・詳細・削除機能を追加

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -1,0 +1,16 @@
+class Admin::MembersController < ApplicationController
+  def index
+    @members = Member.where.not(email: 'guest@example.com').order(created_at: :desc).page(params[:page]).per(15)
+  end
+
+  def show
+    @member = Member.find(params[:id])
+    @posts = @member.posts.order(created_at: :desc)  
+  end
+
+  def destroy
+    @member = Member.find(params[:id])
+    @member.destroy
+    redirect_to admin_members_path, notice: "メンバーを削除しました"
+  end
+end

--- a/app/views/admin/members/index.html.erb
+++ b/app/views/admin/members/index.html.erb
@@ -1,0 +1,25 @@
+<h3 class="mt-4">登録者一覧</h3>
+<table class="table">
+  <thead>
+    <tr>
+      <th>登録ID</th>
+      <th>氏名</th>
+      <th>メールアドレス</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @members.each do |member| %>
+      <tr>
+        <td><%= member.id %></td>
+        <td>
+          <%= link_to member.name, admin_member_path(member), class: "text-primary" %>
+        </td>
+        <td><%= member.email %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="d-flex justify-content-center mt-4">
+  <%= paginate @members, theme: 'bootstrap-5' %>
+</div>

--- a/app/views/admin/members/show.html.erb
+++ b/app/views/admin/members/show.html.erb
@@ -1,0 +1,48 @@
+<section class="inner">
+  <h2 class="section-ttl"><%= @member.name %>さんのマイページ</h2>
+	<table class="customer_info">
+	  <thead>
+	    <th></th>
+		<th></th>
+		<th></th>
+	  </thead>
+	  <tbody>
+	    <tr>
+	      <td>登録ID</td>
+    	  <td colspan="2"><%= @member.id %></td>
+	    </tr>
+	    <tr>
+    	  <td>名前</td>
+    	  <td colspan="2"><%= @member.name %></td>
+	    </tr>
+        <tr>
+    	  <td>メールアドレス</td>
+    	  <td colspan="2"><%= @member.email %></td>
+	    </tr>
+        <tr>
+    	  <td>プロフィール画像</td>
+    	  <td colspan="2"><%= image_tag @member.get_profile_image(50,50), class: "rounded-circle me-3" %></td>
+	    </tr>
+	    <tr>
+    	  <td>プロフィール文</td>
+    	  <td colspan="2"><%= @member.self_introduction %></td>
+	    </tr>
+	    <tr>
+    	  <td>投稿一覧</td>
+    	  <td colspan="2">
+            <% @member.posts.each do |post| %>
+              <%# <li><%= link_to post.title, admin_post_path(post) %></li>
+            <% end %>
+          </td>  
+	    </tr>
+        <tr>
+          <td colspan="2">
+            <%= button_to 'メンバーを削除する', admin_member_path(@member), method: :delete, data: { confirm: "このメンバーのアカウントを削除します。\n削除前に登録メールアドレスへ管理者から直接連絡してください。\n連絡済みであることをご確認の上、続行してください。" }, class: "btn btn-danger" %>
+          </td>
+        </td>
+	  </tbody>
+    </table>
+</section>
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,12 @@
 Rails.application.routes.draw do
 
   namespace :admin do
+    get 'members/index'
+    get 'members/show'
+  end
+  namespace :admin do
     resources :genres, only: [:index, :create, :edit, :update]
+    resources :members, only: [:index, :show, :destroy]
   end
 
   devise_for :admin, skip: [:registrations, :passwords], controllers: {

--- a/test/controllers/admin/members_controller_test.rb
+++ b/test/controllers/admin/members_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Admin::MembersControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get admin_members_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get admin_members_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 管理者用メンバー管理機能の実装

### ✅ 概要
管理者がユーザー（メンバー）情報を確認・削除できる機能を実装しました。  
アプリの健全性維持や、不適切ユーザーの管理を目的としています。

---

### 🛠️ 実装内容

- `Admin::MembersController` を新規作成
- 管理者による以下の機能を実装：
  - メンバー一覧表示（ページネーション付き）
  - メンバー詳細表示（投稿履歴を含む）
  - メンバー削除機能（物理削除）

---

### 💡 補足情報

- ゲストユーザー（`guest@example.com`）は一覧から除外
- 削除後は `admin_members_path` にリダイレクトし、Flashメッセージ表示
- メンバー削除に伴い、ActiveStorage（プロフィール画像）や投稿も削除対象

---

### 🔍 動作確認方法

1. 管理者でログイン
2. 管理画面から「登録者一覧」へアクセス
3. 任意のメンバー詳細ページに遷移
4. 「削除する」ボタンを押下
5. 一覧ページに戻り、「メンバーを削除しました」と表示されることを確認

---

