### PR TITLE
Add: 管理者側に投稿一覧・詳細・削除機能を追加

### DIFF
--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -1,0 +1,8 @@
+class Admin::CommentsController < ApplicationController
+  def destroy
+    comment = Comment.find(params[:id])
+    post = comment.post
+    comment.destroy
+    redirect_to admin_post_path(post), notice: "コメントを削除しました。"
+  end 
+end

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,0 +1,16 @@
+class Admin::PostsController < ApplicationController
+  def index
+    @posts = Post.includes(:member).order(created_at: :desc).page(params[:page]).per(15)
+  end
+
+  def show
+    @post = Post.find(params[:id])
+    @comments = @post.comments.includes(:member).order(created_at: :desc)  
+  end
+
+  def destroy
+    @post = Post.find(params[:id])
+    @post.destroy
+    redirect_to admin_posts_path, notice: "投稿を削除しました。"
+  end
+end

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container genre-form-wrapper">
-  <%= render 'layouts/form_error_messages', object: @genre %>
+  <%= render 'shared/form_error_messages', object: @genre %>
   <%= form_with model: @genre, url: admin_genres_path do |f| %>
     <div class="d-flex justify-content-center align-items-center gap-3 mb-4">
       <div>

--- a/app/views/admin/members/show.html.erb
+++ b/app/views/admin/members/show.html.erb
@@ -31,7 +31,7 @@
     	  <td>投稿一覧</td>
     	  <td colspan="2">
             <% @member.posts.each do |post| %>
-              <%# <li><%= link_to post.title, admin_post_path(post) %></li>
+              <div><%= link_to post.title, admin_post_path(post) %></div>
             <% end %>
           </td>  
 	    </tr>
@@ -39,7 +39,7 @@
           <td colspan="2">
             <%= button_to 'メンバーを削除する', admin_member_path(@member), method: :delete, data: { confirm: "このメンバーのアカウントを削除します。\n削除前に登録メールアドレスへ管理者から直接連絡してください。\n連絡済みであることをご確認の上、続行してください。" }, class: "btn btn-danger" %>
           </td>
-        </td>
+        </tr>
 	  </tbody>
     </table>
 </section>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,0 +1,25 @@
+<h3 class="mt-4">投稿一覧</h3>
+<table class="table">
+  <thead>
+    <tr>
+      <th>投稿日</th>
+      <th>名前</th>
+      <th>タイトル</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @posts.each do |post| %>
+      <tr>
+        <td><%= l(post.created_at, format: :long) %></td>
+        <td><%= post.member.name %></td>
+        <td>
+          <%= link_to post.title, admin_post_path(post), class: "text-primary" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="d-flex justify-content-center mt-4">
+  <%= paginate @posts, theme: 'bootstrap-5' %>
+</div>

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -1,0 +1,61 @@
+<section class="inner">
+  <%= image_tag @post.member.get_profile_image(50, 50), alt: "プロフィール画像", class: "rounded-circle me-3" %>
+  <h2 class="section-ttl"><%= @post.member.name %>さんの投稿詳細</h2>
+	<table class="customer_info">
+	  <thead>
+	    <th></th>
+		<th></th>
+		<th></th>
+	  </thead>
+	  <tbody>
+        <tr>
+	      <td>メールアドレス</td>
+          <td colspan="2"><%= @post.member.email %></td>
+	    </tr>
+        <tr>
+	      <td>投稿日</td>
+    	  <td colspan="2"><%= l(@post.created_at, format: :long) %></td>
+	    </tr>
+	    <tr>
+	      <td>タイトル</td>
+    	  <td colspan="2"><%= @post.title %></td>
+	    </tr>
+        <tr>
+          <td>投稿画像</td>
+          <td>
+            <% if @post.image.attached? %>
+              <%= image_tag @post.get_image(300,200), class: "img-fluid mt-3" %>
+            <% end %>
+          </td>
+        </tr>
+	    <tr>
+    	  <td>ジャンル</td>
+    	  <td colspan="2"><%= @post.genre&.name || "未分類" %></td>
+	    </tr>
+        <tr>
+    	  <td>投稿内容</td>
+    	  <td colspan="2"><%= @post.body %></td>
+	    </tr>
+	    <tr>
+    	  <td>コメント一覧</td>
+    	  <td colspan="2">
+            <% @post.comments.each do |comment| %>
+              <div class="border p-2 mb-2">
+                <p><%= comment.comment_body %></p>
+                <small>投稿者：<%= comment.member.name %>（<%= l(comment.created_at, format: :long) %>）</small>
+                <%= link_to '削除', admin_comment_path(comment), method: :delete, data: { confirm: "このメンバーのコメントを削除します。\n削除前に登録メールアドレスへ管理者から直接連絡してください。\n内容の控えを保存していますか？\n連絡済みであることをご確認の上、続行してください。" }, class: "btn btn-sm btn-danger ms-2" %>
+              </div>
+            <% end %>
+          </td>  
+	    </tr>
+        <tr>
+          <td colspan="2">
+            <%= button_to '投稿を削除する', admin_post_path(@post), method: :delete, data: { confirm: "このメンバーの投稿を削除します。\n削除前に登録メールアドレスへ管理者から直接連絡してください。\n連絡済みであることをご確認の上、続行してください。" }, class: "btn btn-danger" %>
+          </td>
+        </tr>
+	  </tbody>
+    </table>
+</section>
+
+
+

--- a/app/views/public/members/edit_profile.html.erb
+++ b/app/views/public/members/edit_profile.html.erb
@@ -9,7 +9,7 @@
 <div class="container mt-5 px-3 px-md-4">
   <div class="row justify-content-center">
     <div class="col-md-10">
-      <%= render 'public/shared/form_error_messages', object: @member %>
+      <%= render 'shared/form_error_messages', object: @member %>
       <div class="profile-edit-container">
         <%= form_with model: @member, url: update_profile_path, method: :patch do |f| %>
         <h4 class="mb-3">プロフィール画像（任意）</h4>

--- a/app/views/public/posts/_post_list.html.erb
+++ b/app/views/public/posts/_post_list.html.erb
@@ -1,7 +1,7 @@
 <% posts.each do |post| %>
   <div class="card w-50 mx-auto mt-4">
     <div class="card-header bg-white d-flex align-items-center">
-     <%= render 'public/shared/member_summary', member: post.member %>
+     <%= render 'shared/member_summary', member: post.member %>
     </div>
 
     <%= image_tag post.get_image(600, 500), alt: "投稿画像", class: "card-img-top", style: "max-height: 500px; object-fit: cover;" %>

--- a/app/views/public/posts/new.html.erb
+++ b/app/views/public/posts/new.html.erb
@@ -9,7 +9,7 @@
 <div class="containar mt-5 px-3 px-md-4">
   <div class="row justify-content-center">
     <div class="col-md-10">
-      <%= render 'public/shared/form_error_messages', object: @post %>
+      <%= render 'shared/form_error_messages', object: @post %>
       <div class="post-new-container">
         <%= form_with model: @post do |f| %>
           <h4 class="mb-3">投稿画像（任意）</h4>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,10 @@
 Rails.application.routes.draw do
 
   namespace :admin do
-    get 'members/index'
-    get 'members/show'
-  end
-  namespace :admin do
     resources :genres, only: [:index, :create, :edit, :update]
     resources :members, only: [:index, :show, :destroy]
+    resources :posts, only: [:index, :show, :destroy]
+    resources :comments, only: [:destroy]
   end
 
   devise_for :admin, skip: [:registrations, :passwords], controllers: {

--- a/test/controllers/admin/comments_controller_test.rb
+++ b/test/controllers/admin/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Admin::CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/admin/posts_controller_test.rb
+++ b/test/controllers/admin/posts_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Admin::PostsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get admin_posts_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get admin_posts_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 管理者による投稿およびコメント管理機能の実装

### 実装内容

- 管理者側の投稿管理機能を追加
  - `Admin::PostsController` を新規作成
  - 投稿一覧ページ（`index`）を実装し、タイトル・投稿者名・投稿日時を表示
  - 投稿詳細ページ（`show`）を実装し、投稿内容とコメント一覧を表示
  - 投稿削除機能（`destroy`）を追加
- 管理者側のコメント管理機能を追加
  - `Admin::CommentsController` を新規作成
  - コメント削除機能（`destroy`）を実装
  
