### PR TITLE
Update: 管理者用レイアウトの見た目を修正

### DIFF
--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -3,6 +3,6 @@ class Admin::CommentsController < ApplicationController
     comment = Comment.find(params[:id])
     post = comment.post
     comment.destroy
-    redirect_to admin_post_path(post), notice: "コメントを削除しました。"
+    redirect_to admin_post_path(post), notice: "コメントを削除しました"
   end 
 end

--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -1,5 +1,5 @@
 class Admin::GenresController < ApplicationController
-  before_action :ensure_genre, only: [:edit, :update]
+  before_action :ensure_genre, only: [:edit, :update, :destroy]
   
   def index
     @genre = Genre.new
@@ -25,6 +25,11 @@ class Admin::GenresController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    @genre.destroy
+    redirect_to admin_genres_path, notice: "ジャンルを削除しました"
   end
 
   private

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -11,6 +11,6 @@ class Admin::PostsController < ApplicationController
   def destroy
     @post = Post.find(params[:id])
     @post.destroy
-    redirect_to admin_posts_path, notice: "投稿を削除しました。"
+    redirect_to admin_posts_path, notice: "投稿を削除しました"
   end
 end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -2,7 +2,25 @@
 
 class Admin::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  def after_sign_in_path_for(resource)
+    admin_posts_path
+  end
 
+  def after_sign_out_path_for(resource)
+    root_path
+  end
+
+  def create
+    super do |resource|
+      flash[:notice] = t('devise.sessions.admin_signed_in') if resource.is_a?(Admin)
+    end
+  end
+  
+  def destroy
+    super do
+      flash[:notice] = t('devise.sessions.admin_signed_out')
+    end
+  end
   # GET /resource/sign_in
   # def new
   #   super

--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -2,6 +2,8 @@ class Public::HomesController < ApplicationController
   def top
     if member_signed_in?
       redirect_to member_path(current_member)
+    elsif admin_signed_in?
+      redirect_to admin_posts_path
     end
   end
 

--- a/app/views/admin/comments/_comments_list.html.erb
+++ b/app/views/admin/comments/_comments_list.html.erb
@@ -1,0 +1,19 @@
+<% if comments.any? %>
+  <% comments.each do |comment| %>
+    <div class="card mb-3">
+      <div class="card-body">
+        <p class="mb-1"><%= comment.comment_body %></p>
+        <small class="text-muted">
+          投稿者：<%= comment.member.name %>（<%= l(comment.created_at, format: "%Y/%m/%d %H:%M") %>）
+        </small>
+        <%= link_to '削除', admin_comment_path(comment), method: :delete,
+          data: {
+            confirm: "このメンバーのコメントを削除します。\n削除前に登録メールアドレスへ管理者から直接連絡してください。\n内容の控えを保存していますか？\n連絡済みであることをご確認の上、続行してください。"
+          },
+          class: "btn btn-sm btn-outline-danger float-end" %>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <p class="text-muted">コメントはありません。</p>
+<% end %>

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container genre-edit-form">
-  <%= render 'layouts/form_error_messages', object: @genre %>
+  <%= render 'shared/form_error_messages', object: @genre %>
 
   <h3 class="text-center mb-4 genre-heading">ジャンル編集</h3>
 

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container genre-form-wrapper">
+<div class="container mt-4 mb-4 genre-form-wrapper">
   <%= render 'shared/form_error_messages', object: @genre %>
   <%= form_with model: @genre, url: admin_genres_path do |f| %>
     <div class="d-flex justify-content-center align-items-center gap-3 mb-4">
@@ -16,7 +16,7 @@
 </div>
 
 <div class="mt-5">
-  <table class="table w-25 mx-auto align-middle ext-nowrap">
+  <table class="table table-bordered w-25 mx-auto align-middle ext-nowrap">
     <thead class="table-success">
       <tr>
         <th class="fw-normal">ジャンル名</th>
@@ -29,10 +29,10 @@
         <tr>
           <td><%= genre.name %></td>
           <td>
-            <%= link_to "編集する", edit_admin_genre_path(genre), class: "btn btn-outline-success" %>
+            <%= link_to "編集", edit_admin_genre_path(genre), class: "btn btn-outline-success" %>
           </td>
           <td>
-            <%= link_to "削除する", admin_genre_path(genre), class: "btn btn-outline-danger" %>
+            <%= link_to "削除", admin_genre_path(genre), method: :delete, class: "btn btn-outline-danger" %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/members/index.html.erb
+++ b/app/views/admin/members/index.html.erb
@@ -1,25 +1,28 @@
-<h3 class="mt-4">登録者一覧</h3>
-<table class="table">
-  <thead>
-    <tr>
-      <th>登録ID</th>
-      <th>氏名</th>
-      <th>メールアドレス</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @members.each do |member| %>
-      <tr>
-        <td><%= member.id %></td>
-        <td>
-          <%= link_to member.name, admin_member_path(member), class: "text-primary" %>
-        </td>
-        <td><%= member.email %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<div class="container w-75 mt-4 mb-4">
+  <h2 class="mb-4">登録者一覧</h2>
 
-<div class="d-flex justify-content-center mt-4">
-  <%= paginate @members, theme: 'bootstrap-5' %>
+  <table class="table table-bordered">
+    <thead>
+      <tr class="table-success">
+        <th>登録ID</th>
+        <th>氏名</th>
+        <th>メールアドレス</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @members.each do |member| %>
+        <tr>
+          <td><%= member.id %></td>
+          <td>
+            <%= link_to member.name, admin_member_path(member), class: "text-primary" %>
+          </td>
+          <td><%= member.email %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  
+  <div class="d-flex justify-content-center mt-4">
+    <%= paginate @members, theme: 'bootstrap-5' %>
+  </div>
 </div>

--- a/app/views/admin/members/show.html.erb
+++ b/app/views/admin/members/show.html.erb
@@ -1,48 +1,58 @@
-<section class="inner">
-  <h2 class="section-ttl"><%= @member.name %>さんのマイページ</h2>
-	<table class="customer_info">
-	  <thead>
-	    <th></th>
-		<th></th>
-		<th></th>
-	  </thead>
-	  <tbody>
-	    <tr>
-	      <td>登録ID</td>
-    	  <td colspan="2"><%= @member.id %></td>
-	    </tr>
-	    <tr>
-    	  <td>名前</td>
-    	  <td colspan="2"><%= @member.name %></td>
-	    </tr>
-        <tr>
-    	  <td>メールアドレス</td>
-    	  <td colspan="2"><%= @member.email %></td>
-	    </tr>
-        <tr>
-    	  <td>プロフィール画像</td>
-    	  <td colspan="2"><%= image_tag @member.get_profile_image(50,50), class: "rounded-circle me-3" %></td>
-	    </tr>
-	    <tr>
-    	  <td>プロフィール文</td>
-    	  <td colspan="2"><%= @member.self_introduction %></td>
-	    </tr>
-	    <tr>
-    	  <td>投稿一覧</td>
-    	  <td colspan="2">
+<div class="container w-75 mt-4 mb-5">
+  <h2 class="mb-4"><%= @member.name %>さんのマイページ</h2>
+
+  <table class="table table-bordered">
+    <thead>
+      <tr class="table-success text-center">
+        <th class="w-25">項目名</th>
+        <th>内容</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>登録ID</th>
+        <td><%= @member.id %></td>
+      </tr>
+      <tr>
+        <th>名前</th>
+        <td><%= @member.name %></td>
+      </tr>
+      <tr>
+        <th>メールアドレス</th>
+        <td><%= @member.email %></td>
+      </tr>
+      <tr>
+        <th>プロフィール画像</th>
+        <td>
+          <%= image_tag @member.get_profile_image(100, 100), class: "rounded-circle me-2" %>
+        </td>
+      </tr>
+      <tr>
+        <th>プロフィール文</th>
+        <td><%= @member.self_introduction.presence || "未登録" %></td>
+      </tr>
+      <tr>
+        <th>投稿一覧</th>
+        <td>
+          <% if @member.posts.any? %>
             <% @member.posts.each do |post| %>
               <div><%= link_to post.title, admin_post_path(post) %></div>
             <% end %>
-          </td>  
-	    </tr>
-        <tr>
-          <td colspan="2">
-            <%= button_to 'メンバーを削除する', admin_member_path(@member), method: :delete, data: { confirm: "このメンバーのアカウントを削除します。\n削除前に登録メールアドレスへ管理者から直接連絡してください。\n連絡済みであることをご確認の上、続行してください。" }, class: "btn btn-danger" %>
-          </td>
-        </tr>
-	  </tbody>
-    </table>
-</section>
-
-
-
+          <% else %>
+            <span class="text-muted">投稿はありません。</span>
+          <% end %>
+        </td>
+      </tr>
+      <tr>
+        <th>アカウント削除</th>
+        <td class="text-center">
+          <%= button_to 'メンバーを削除する', admin_member_path(@member), method: :delete,
+            data: {
+              confirm: "このメンバーのアカウントを削除します。\n削除前に登録メールアドレスへ管理者から直接連絡してください。\n連絡済みであることをご確認の上、続行してください。"
+            },
+            class: "btn btn-danger" %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,25 +1,28 @@
-<h3 class="mt-4">投稿一覧</h3>
-<table class="table">
-  <thead>
-    <tr>
-      <th>投稿日</th>
-      <th>名前</th>
-      <th>タイトル</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @posts.each do |post| %>
-      <tr>
-        <td><%= l(post.created_at, format: :long) %></td>
-        <td><%= post.member.name %></td>
-        <td>
-          <%= link_to post.title, admin_post_path(post), class: "text-primary" %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<div class="container w-75 mt-4 mb-4">
+  <h2 class="mb-4">投稿一覧</h2>
 
-<div class="d-flex justify-content-center mt-4">
-  <%= paginate @posts, theme: 'bootstrap-5' %>
+  <table class="table table-bordered">
+    <thead>
+      <tr class="table-success">
+        <th>投稿日</th>
+        <th>名前</th>
+        <th>タイトル</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @posts.each do |post| %>
+        <tr>
+          <td><%= l(post.created_at, format: :long) %></td>
+          <td><%= post.member.name %></td>
+          <td>
+            <%= link_to post.title, admin_post_path(post), class: "text-primary" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <div class="d-flex justify-content-center mt-4">
+    <%= paginate @posts, theme: 'bootstrap-5' %>
+  </div>
 </div>

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -1,61 +1,63 @@
-<section class="inner">
-  <%= image_tag @post.member.get_profile_image(50, 50), alt: "プロフィール画像", class: "rounded-circle me-3" %>
-  <h2 class="section-ttl"><%= @post.member.name %>さんの投稿詳細</h2>
-	<table class="customer_info">
-	  <thead>
-	    <th></th>
-		<th></th>
-		<th></th>
-	  </thead>
-	  <tbody>
-        <tr>
-	      <td>メールアドレス</td>
-          <td colspan="2"><%= @post.member.email %></td>
-	    </tr>
-        <tr>
-	      <td>投稿日</td>
-    	  <td colspan="2"><%= l(@post.created_at, format: :long) %></td>
-	    </tr>
-	    <tr>
-	      <td>タイトル</td>
-    	  <td colspan="2"><%= @post.title %></td>
-	    </tr>
-        <tr>
-          <td>投稿画像</td>
-          <td>
-            <% if @post.image.attached? %>
-              <%= image_tag @post.get_image(300,200), class: "img-fluid mt-3" %>
-            <% end %>
-          </td>
-        </tr>
-	    <tr>
-    	  <td>ジャンル</td>
-    	  <td colspan="2"><%= @post.genre&.name || "未分類" %></td>
-	    </tr>
-        <tr>
-    	  <td>投稿内容</td>
-    	  <td colspan="2"><%= @post.body %></td>
-	    </tr>
-	    <tr>
-    	  <td>コメント一覧</td>
-    	  <td colspan="2">
-            <% @post.comments.each do |comment| %>
-              <div class="border p-2 mb-2">
-                <p><%= comment.comment_body %></p>
-                <small>投稿者：<%= comment.member.name %>（<%= l(comment.created_at, format: :long) %>）</small>
-                <%= link_to '削除', admin_comment_path(comment), method: :delete, data: { confirm: "このメンバーのコメントを削除します。\n削除前に登録メールアドレスへ管理者から直接連絡してください。\n内容の控えを保存していますか？\n連絡済みであることをご確認の上、続行してください。" }, class: "btn btn-sm btn-danger ms-2" %>
-              </div>
-            <% end %>
-          </td>  
-	    </tr>
-        <tr>
-          <td colspan="2">
-            <%= button_to '投稿を削除する', admin_post_path(@post), method: :delete, data: { confirm: "このメンバーの投稿を削除します。\n削除前に登録メールアドレスへ管理者から直接連絡してください。\n連絡済みであることをご確認の上、続行してください。" }, class: "btn btn-danger" %>
-          </td>
-        </tr>
-	  </tbody>
-    </table>
-</section>
+<div class="container w-75 mt-4 mb-5">
+  <div class="d-flex align-items-center mb-4">
+    <%= image_tag @post.member.get_profile_image(70, 70), alt: "プロフィール画像", class: "rounded-circle me-3" %>
+    <h2 class="mb-0"><%= @post.member.name %>さんの投稿詳細</h2>
+  </div>
 
-
-
+  <table class="table table-bordered">
+    <thead>
+      <tr class="table-success text-center">
+        <th class="w-25">項目名</th>
+        <th>内容</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>メールアドレス</th>
+        <td><%= @post.member.email %></td>
+      </tr>
+      <tr>
+        <th>投稿日</th>
+        <td><%= l(@post.created_at ,format: "%Y/%m/%d %H:%M") %></td>
+      </tr>
+      <tr>
+        <th>タイトル</th>
+        <td><%= @post.title %></td>
+      </tr>
+      <tr>
+        <th>投稿画像</th>
+        <td>
+          <% if @post.image.attached? %>
+            <%= image_tag @post.get_image(300, 200), class: "img-fluid mt-2" %>
+          <% else %>
+            <span class="text-muted">画像なし</span>
+          <% end %>
+        </td>
+      </tr>
+      <tr>
+        <th>ジャンル</th>
+        <td><%= @post.genre&.name || "未分類" %></td>
+      </tr>
+      <tr>
+        <th>投稿内容</th>
+        <td><%= @post.body %></td>
+      </tr>
+      <tr>
+        <th>コメント一覧</th>
+        <td>
+          <%= render 'admin/comments/comments_list', comments: @post.comments %>
+        </td>
+      </tr>
+      <tr>
+        <th>投稿削除</th>
+        <td class="text-center">
+          <%= button_to '投稿を削除する', admin_post_path(@post), method: :delete,
+            data: {
+              confirm: "このメンバーの投稿を削除します。\n削除前に登録メールアドレスへ管理者から直接連絡してください。\n連絡済みであることをご確認の上、続行してください。"
+            },
+            class: "btn btn-danger" %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -1,0 +1,30 @@
+<header class="header">
+  <div class="header-row">
+    <nav class="navbar navbar-expand-lg bg-light navbar-light">
+      <div class="container-fluid px-5">
+        <%= link_to admin_posts_path, class: "navbar-brand" do %>
+          <%= image_tag "tsunagari_logo_flower.png", alt: "つながり広場のロゴ", width: 120, height: 80 %>
+        <% end %>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav ms-auto">
+            <li class="nav-item">
+              <%= link_to "投稿一覧", admin_posts_path, class: "nav-link" %>
+            </li>
+            <li class="nav-item">
+              <%= link_to "登録者一覧", admin_members_path, class: "nav-link" %>
+            </li>
+            <li class="nav-item">
+              <%= link_to "ジャンル一覧", admin_genres_path, class: "nav-link" %>
+            </li> 
+            <li class="nav-item">
+              <%= link_to "ログアウト", destroy_admin_session_path, method: :delete, class: "nav-link" %>
+            </li>
+          </ul>
+        </div>
+      </div><%# container-fluid px-5 %>
+    </nav>
+  </div><%# header-row %>
+</header>

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,0 +1,11 @@
+<% if notice %>
+  <div class="alert alert-success text-center container w-50 mt-4 mb-4">
+    <%= notice %>
+  </div>
+<% end %>
+
+<% if alert %>
+  <div class="alert alert-danger text-center container w-50 mt-4 mb-4">
+    <%= alert %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,13 +12,9 @@
   </head>
 
   <body>
-
-    <p>lorem ipsum</p>
-    
     <% if member_signed_in? && current_member.guest? %>
       <%= render 'layouts/guest_header' %>
-      <p class="notice"><%= notice %></p>
-      <p class="alert"><%= alert %></p>
+      <%= render 'layouts/flash_messages' %>
       <%= yield %>
     <% elsif member_signed_in? %>
       <div class="layout">
@@ -31,10 +27,13 @@
           </div>
         </div>
       </div>
+    <% elsif admin_signed_in? %>
+      <%= render 'layouts/admin_header' %>
+      <%= render 'layouts/flash_messages' %>
+      <%= yield %>
     <% else %>
       <%= render 'layouts/header' %>
-      <p class="notice"><%= notice %></p>
-      <p class="alert"><%= alert %></p>
+      <%= render 'layouts/flash_messages' %>
       <%= yield %>
     <% end %>
   </body>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,9 @@ module Tunagarihiroba
 
     config.i18n.load_path += Dir[Rails.root.join('config/locales/*.yml').to_s]
 
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -114,7 +114,9 @@ ja:
       new:
         sign_in: ログイン
       signed_in: ようこそ、つながり広場へ！
+      admin_signed_in: 管理者としてログインしました。
       signed_out: ご利用ありがとうございました。またいつでもお越しください。
+      admin_signed_out: 管理画面からログアウトしました。
     shared:
       links:
         back: 戻る

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   namespace :admin do
-    resources :genres, only: [:index, :create, :edit, :update]
+    resources :genres, only: [:index, :create, :edit, :update, :destroy]
     resources :members, only: [:index, :show, :destroy]
     resources :posts, only: [:index, :show, :destroy]
     resources :comments, only: [:destroy]


### PR DESCRIPTION
## 概要
管理者機能の視認性・操作性を向上させるため、以下のレイアウト調整と処理追加を行いました。  
あわせて、ログイン／ログアウト後の動作を最適化し、ユーザー種別による分岐表示の明確化も実施しました。

## 実装内容
- 管理者ログイン／ログアウト後のリダイレクト先とフラッシュメッセージを明確化
- `devise.ja.yml` にて管理者専用メッセージを追加
- トップページアクセス時に、管理者ログイン済であれば管理画面へ自動遷移
- 投稿詳細画面にてコメント一覧表示をパーシャルに切り出し再利用性を向上
- 管理者用レイアウト（ヘッダー）を新規作成し、各種リンクを明示
- フラッシュメッセージ用の共通テンプレートを導入し、全レイアウトで一貫表示を実現
- `application.html.erb` にてログイン状態に応じたレイアウト切り替えを明示的に設定
- Railsの時刻表示設定を日本時間に統一

## 対象ファイル
- `admin/sessions_controller.rb`
- `public/homes_controller.rb`
- `views/admin/comments/_comments_list.html.erb`
- `views/admin/posts/show.html.erb`
- `views/admin/posts/index.html.erb`
- `views/admin/members/show.html.erb`
- `views/admin/members/index.html.erb`
- `views/layouts/_admin_header.html.erb`
- `views/layouts/_flash_messages.html.erb`
- `views/layouts/application.html.erb`
- `config/application.rb`
- `config/locales/devise.ja.yml`

## 確認方法
1. 管理者アカウントでログイン／ログアウトし、メッセージ表示と遷移先が正しいかを確認
2. トップページ `/` にアクセスし、ログイン状態によって表示が適切に分岐されることを確認
3. 投稿詳細ページにてコメント一覧と削除ボタンのレイアウトが崩れていないか確認
4. 全体レイアウト（ヘッダー・メッセージ表示）が意図通り表示されているかを各ログイン状態で確認
5. 日付・時間表示が JST（日本標準時）に変更されているかを確認

## 補足
- フラッシュメッセージはログイン種別ごとにカスタマイズされ、ユーザーの操作意図と連動した通知が実現されています
- コメント削除・投稿削除の際は、注意喚起メッセージも強化し、管理者としての慎重な判断を促す構成としています
- `application.html.erb` の条件分岐により、ゲスト／会員／管理者ごとに明確なレイアウトが適用されるようになっています