### PR TITLE
Add: 会員機能に論理削除（退会）処理を追加

### DIFF
--- a/app/controllers/public/notifications_controller.rb
+++ b/app/controllers/public/notifications_controller.rb
@@ -4,7 +4,9 @@ class Public::NotificationsController < ApplicationController
   before_action :check_user_status
 
   def index
-    @notifications = current_member.passive_notifications.includes(:visitor, :post, :comment).page(params[:page]).per(15)
+    base_scope = current_member.passive_notifications.joins(:visitor).merge(Member.available)
+    @notifications = base_scope.includes(:visitor, :post, :comment).page(params[:page]).per(15)
+    
     @notifications.where(checked: false).each do |notification|
       notification.update(checked: true)
     end    

--- a/app/controllers/public/reports_controller.rb
+++ b/app/controllers/public/reports_controller.rb
@@ -15,7 +15,7 @@ class Public::ReportsController < ApplicationController
     @report.reported_id = @member.id 
 
     if @report.save
-      redirect_to member_path(@member)
+      redirect_to member_path(@member), notice: "通報が完了しました。"
     else
       render :new
     end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -14,6 +14,8 @@ class Member < ApplicationRecord
 
   enum user_status: { available: 0, suspended: 1 }
 
+  scope :available, -> { where(user_status: :available) }
+
   has_one_attached :profile_image, dependent: :destroy  
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
@@ -29,6 +31,7 @@ class Member < ApplicationRecord
   has_many :reports_received, class_name: "Report", foreign_key: "reported_id", dependent: :destroy
 
   validates :name, presence: true, on: :update_profile
+  validates :user_status, presence: true
 
   def report_count
     Report.where(reported_id: id).count

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,6 +5,10 @@ class Post < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :saved_posts, dependent: :destroy
   has_many :notifications, dependent: :destroy
+  
+  scope :with_available_members, -> {
+    joins(:member).merge(Member.available).includes(:member, :genre)
+  }
 
   def get_image(width, height)
     unless image.attached?

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -34,6 +34,7 @@
   </div><%# w-75 container %>
 </nav><%# navbar border-bottom mt-4 %>
 
+<%= render 'layouts/flash_messages' %>
 <div class="card-list-container py-5">
   <% @posts.each do |post| %>
   <div class="card w-50 mx-auto mt-4">

--- a/app/views/public/members/unsubscribe.html.erb
+++ b/app/views/public/members/unsubscribe.html.erb
@@ -5,13 +5,13 @@
         <h3 class="fw-bold">本当に退会しますか？</h3>
       </div>
       <h5 class="mb-5">
-        退会すると、これまでのすべての投稿や「つながり」の記録が完全に削除されます。<br>
-        一度退会すると、情報の復元はできません。<br>
+        退会すると、あなたのアカウントは利用できなくなり、<br>
+        投稿や「つながり」の機能も停止されます。<br>
         内容をよくご確認のうえ、退会をご希望の場合は、下の「退会する」ボタンを押してください。
       </h5>
       <div class="d-flex justify-content-center gap-5">
         <%= link_to "退会しない", member_path(current_member), class: "btn btn-success btn-lg px-4" %>
-        <%= button_to "退会する", registration_path(:member), method: :delete, class: "btn btn-danger btn-lg px-4" %>
+        <%= button_to "退会する", withdraw_path, method: :patch, class: "btn btn-danger btn-lg px-4", data: { confirm: "本当に退会しますか？" } %>
       </div>
     </div>
   </div>

--- a/app/views/public/notifications/index.html.erb
+++ b/app/views/public/notifications/index.html.erb
@@ -13,6 +13,8 @@
     <%= paginate @notifications, theme: 'bootstrap-5' %>
   </div>
 <% else %>
-  <p>通知はありません</p>
+  <div class="d-flex justify-content-center mt-4">
+    <h4>通知はありません。</h4>
+  </div>
 <% end %>
 

--- a/app/views/public/relationships/create.js.erb
+++ b/app/views/public/relationships/create.js.erb
@@ -1,2 +1,1 @@
 $("#relastionships-btn-<%= @member.id %>").html("<%= j(render 'public/relationships/follow_btn', member: @member) %>");
-$(".relastionships-index<%= @member.id %>").html("<%= j(render 'public/relationships/follow_delete_btn', member: @member) %>");

--- a/app/views/public/reports/new.html.erb
+++ b/app/views/public/reports/new.html.erb
@@ -32,7 +32,9 @@
 
           <%= form_with model:[@member, @report], class: "my-4" do |f| %>
             <div class="form-group d-flex justify-content-center mb-4">
-              <%= f.text_area :reason, rows: '6', class: "form-control" %>
+              <div class="w-100">
+                <%= f.text_area :reason, rows: 6, class: "form-control" %>
+              </div>
             </div>
             <div class="form-group d-flex justify-content-center">
               <%= f.submit "通報する",data: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
     get 'how_to', to: 'homes#how_to'
     get '/members/edit_profile', to: 'members#edit_profile', as: 'edit_profile'
     patch '/members/update_profile', to: 'members#update_profile', as: 'update_profile'
+    patch '/members/withdraw', to: 'members#withdraw', as: 'withdraw'
     get '/members/unsubscribe', to: 'members#unsubscribe', as: 'unsubscribe'
     get '/members/saved_posts', to: 'members#saved_posts', as: 'saved_posts'
 


### PR DESCRIPTION
## 概要

会員の論理削除機能（退会ステータス管理）を実装しました。  
これにより、退会済みの会員による投稿・コメント・通知等が他ユーザーに表示されないよう制御されます。  
また、退会は物理削除ではなく `user_status` による状態管理（enum）で実現しています。

---

## 実装内容

- `Member`モデルに `enum user_status: { available: 0, suspended: 1 }` を追加
- `Member.available` スコープの定義と活用
- 各コントローラーで `available` 状態であるかを確認する処理を追加
  - `PostsController`：投稿一覧・詳細・フォロー中一覧にスコープ適用
  - `MembersController`：プロフィール表示制限、退会処理（withdrawアクション）追加
  - `NotificationsController`：退会済みユーザーによる通知を除外
  - `ReportsController`：通報成功時のリダイレクトを調整
- 退会処理のルーティング追加：`patch /members/withdraw` を新設
- `unsubscribe.html.erb` の文言修正および退会処理ボタンのルート変更
- 各ビューで「退会済みユーザーに関するデータを表示しない」ように制御
- フラッシュメッセージやエラーハンドリングの強化

---

## 変更・追加ファイル一覧

- `app/controllers/public/members_controller.rb`
- `app/controllers/public/notifications_controller.rb`
- `app/controllers/public/posts_controller.rb`
- `app/controllers/public/reports_controller.rb`
- `app/models/member.rb`
- `app/models/post.rb`
- `app/views/public/members/show.html.erb`
- `app/views/public/members/unsubscribe.html.erb`
- `app/views/public/notifications/index.html.erb`
- `app/views/public/relationships/create.js.erb`
- `app/views/public/reports/new.html.erb`
- `config/routes.rb`

---

## 確認方法

1. 任意のアカウントでログイン
2. プロフィール編集 → 退会画面 → 「退会する」を選択
3. ログアウトされ、トップページに遷移する
4. そのアカウントのプロフィールや投稿は他ユーザーに表示されない
5. 通知やコメント一覧でも、退会者関連のデータが除外されている