### PR TITLE
Fix: 自分がコメントした投稿に他者がコメントしても、自分に通知が届かないよう通知生成処理を修正

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -23,11 +23,8 @@ class Post < ApplicationRecord
   end
 
   def create_notification_comment!(current_member, comment_id)
-    temp_ids = Comment.select(:member_id).where(post_id: id).where.not(member_id: current_member.id).distinct
-    temp_ids.each do |temp_id|
-      save_notification_comment!(current_member, comment_id, temp_id['member_id'])
-    end
-    save_notification_comment!(current_member, comment_id, member_id) if temp_ids.blank?
+    return if member_id == current_member.id  
+    save_notification_comment!(current_member, comment_id, member_id)
   end
 
   def save_notification_comment!(current_member, comment_id, visited_id)


### PR DESCRIPTION
高齢者にも直感的に使いやすいアプリを目指し、コメント通知のロジックを見直しました。

当初は「自分がコメントした投稿に他の人がコメントした場合」にも通知が届く仕様としていました。これは交流の輪を広げることを目的としたものでしたが、高齢者ユーザーにとっては、「なぜこの通知が来たのか分かりにくい」という混乱を招く可能性があると判断しました。

そのため、今回の修正では「投稿者本人にのみコメント通知が届く」というシンプルな仕様に変更しました。これにより、通知の意味が明確になり、アプリ全体の操作性と安心感の向上につながると考えています。

対象ファイル：`app/models/post.rb` の `create_notification_comment!` メソッド内のロジックを調整