### PR TITLE
Fix: 非アクティブユーザーのコメントが表示される不具合を修正

### DIFF
--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -38,7 +38,7 @@ class Public::PostsController < ApplicationController
 
   def show
     @comment = Comment.new
-    @comments = @post.comments.joins(:member).merge(Member.available)
+    @comments = @post.comments.with_available_members
   end
 
   def followings

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,5 +2,9 @@ class Comment < ApplicationRecord
   belongs_to :member
   belongs_to :post
 
+  scope :with_available_members, -> {
+    joins(:member).merge(Member.available).includes(:member)
+  }
+
   validates :comment_body, presence: true
 end

--- a/app/views/public/comments/_index.html.erb
+++ b/app/views/public/comments/_index.html.erb
@@ -1,4 +1,4 @@
-<% post.comments.each do |comment| %>
+<% comments.each do |comment| %>
   <div class="d-flex flex-column flex-md-row border-bottom align-items-start justify-content-between py-3 gap-2">
     <div class="d-flex flex-column flex-md-row align-items-md-center w-100">
       <%= link_to member_path(comment.member), class: "text-decoration-none link-dark d-flex align-items-center mb-2 mb-md-0 me-md-3" do %>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -28,7 +28,7 @@
       <div class="container bg-light rounded-3 py-5 px-4 align-items-center justify-content-between">
         <h5>コメントを書いて応援しましょう</h5>
         <div class="comments-index">
-          <%= render 'public/comments/index', post: @post %>
+          <%= render 'public/comments/index', comments: @comments %>
         </div>
         <div class="error-message-area"></div>
         <% unless current_member&.guest? %>


### PR DESCRIPTION
## 概要
コメント一覧に対して、退会済みユーザーのコメントが表示されないように制御しました。

## 実施内容
- Commentモデルに `with_available_members` スコープを新規追加
- Memberモデルの `available` スコープを活用し、`user_status: :available` のみを対象とするよう統一
- 投稿詳細画面にて、`@post.comments.with_available_members` を用いてコメント一覧を取得するよう修正

## 背景・目的
これまで投稿一覧やフォロー一覧では退会済みユーザーの情報が非表示になっていましたが、コメント一覧には退会済みユーザーのコメントが表示されていました。  
本対応により、投稿詳細画面においても一貫したユーザー表示制御が可能となりました。

## 動作確認
- 退会済みユーザーのコメントが投稿詳細画面で表示されないことを確認
- アクティブユーザーのコメントは従来通り表示されることを確認