### PR TITLE
Fix: 通知一覧において非アクティブユーザーを除外しつつ、全通知の既読処理を実行

### DIFF
--- a/app/controllers/public/notifications_controller.rb
+++ b/app/controllers/public/notifications_controller.rb
@@ -4,11 +4,13 @@ class Public::NotificationsController < ApplicationController
   before_action :check_user_status
 
   def index
-    base_scope = current_member.passive_notifications.joins(:visitor).merge(Member.available)
-    @notifications = base_scope.includes(:visitor, :post, :comment).page(params[:page]).per(15)
-    
-    @notifications.where(checked: false).each do |notification|
+    # 非アクティブ含めて既読処理
+    current_member.passive_notifications.where(checked: false).each do |notification|
       notification.update(checked: true)
-    end    
+    end 
+
+    # 表示はアクティブユーザーからのみに限定
+    base_scope = current_member.passive_notifications.joins(:visitor).merge(Member.available)
+    @notifications = base_scope.includes(:visitor, :post, :comment).page(params[:page]).per(15) 
   end
 end


### PR DESCRIPTION
## 概要
通知の既読処理については、表示・非表示に関わらず全件を対象に checked: true となるよう修正しました。

## 目的
- 非表示の通知も既読にすることで、通知バッジ（オレンジ点灯）が残り続ける不具合を防止するため

## 対応内容
- `current_member.passive_notifications.where(checked: false)` を使い、全通知を既読処理
- 通知の表示対象は `.joins(:visitor).merge(Member.available)` によって制限

## 備考
- `member.rb` で定義されている `scope :available` を使用し、ユーザーステータスが `available` のみを対象としています。