### PR TITLE
Add: 未読通知件数をバッジで可視化

### DIFF
--- a/app/views/shared/_notification_icon.html.erb
+++ b/app/views/shared/_notification_icon.html.erb
@@ -1,12 +1,11 @@
-<%= link_to notifications_path, class: "nav-link text-body" do %>
-  <% if unchecked_notifications.any? %>
-    <span class="fa-stack me-2">
-      <i class="fa-regular fa-bell n-bell fa-stack-1x"></i>
-      <i class="fa-solid fa-circle n-circle fa-stack-0.5x"></i>
-    </span>
-  <% else %>
-    <i class="fa-regular fa-bell me-2"></i>
-  <% end %>
-    <span>通知一覧</span>
-<% end %>
+<% unread_count = unchecked_notifications.count %>
 
+<%= link_to notifications_path, class: "nav-link text-body d-flex align-items-center" do %>
+  <i class="fa-regular fa-bell me-2"></i>
+  <span>通知一覧</span>
+  <% if unread_count > 0 %>
+    <span class="badge rounded-pill bg-danger ms-2">
+      <%= unread_count %>
+    </span>
+  <% end %>
+<% end %>


### PR DESCRIPTION
## 概要
通知一覧への導線に、未読通知の件数をバッジ形式で表示する機能を追加しました。

## 背景
これまでは通知の存在を示すのがオレンジ色のアイコンのみであり、高齢者ユーザーには視認性に乏しく、変化に気づきにくい設計となっていました。

## 変更内容

- `notifications_path` のリンクに未読件数を表示するバッジを追加
- `unchecked_notifications.count` を使用し、未読が1件以上ある場合のみバッジを表示
- Bootstrap の `badge` および `rounded-pill` クラスでスタイルを調整

## 目的
通知件数を赤色のバッジで明示することで、視覚的に変化が伝わりやすくなり、高齢者でも気づきやすい設計を実現します。

## 補足
ドロップダウン形式ではなく、ナビゲーションバーの「通知一覧」リンクの横に数字を表示する、シンプルで明快なデザインです。