### PR TITLE
Fix: 非表示ユーザーを除外したコメント一覧の描画処理を修正（create.js.erb）

### DIFF
--- a/app/views/public/comments/create.js.erb
+++ b/app/views/public/comments/create.js.erb
@@ -1,2 +1,2 @@
 $('.form-control').val("")
-$('.comments-index').html("<%= j(render 'public/comments/index', post: @comment.post) %>")
+$('.comments-index').html("<%= j(render 'public/comments/index', comments: @comment.post.comments.with_available_members) %>")


### PR DESCRIPTION
## 概要  
非同期コメント描画時（create.js.erb）に `comments` が未定義のためエラーが発生していた問題を修正しました。

## 背景  
コメント投稿時に部分テンプレート `public/comments/_index.html.erb` を再描画する処理において、ローカル変数 `comments` が適切に渡されておらず、`undefined local variable or method 'comments'` のエラーが発生していました。

## 変更内容  
- `create.js.erb` の `render` 呼び出しを修正し、`comments:` に `@comment.post.comments.with_available_members` を渡すよう修正  
- `_index.html.erb` では `comments.each` を使用しているため、ローカル変数 `comments` を明示的に渡す必要があった

## 目的  
非同期処理での描画エラーを解消し、コメント投稿後に画面が正しく更新されるようにするため。

## 補足  
なお、`with_available_members` を適用することで、退会済みユーザーのコメントが表示されない仕様も同時に維持しています。