### PR TITLE
Fix: マイページ投稿一覧を新着順に変更

### DIFF
--- a/app/controllers/public/members_controller.rb
+++ b/app/controllers/public/members_controller.rb
@@ -5,7 +5,7 @@ class Public::MembersController < ApplicationController
   before_action :check_user_status
 
   def show
-    @posts = @member.posts.page(params[:page])
+    @posts = @member.posts.order(created_at: :desc).page(params[:page])
   end
 
 


### PR DESCRIPTION
## 概要
マイページ（members#show）に表示される投稿一覧が、初期状態では投稿順（古い順）になっていたため、新着順（created_at: :desc）に変更しました。

## 変更内容
- `@member.posts.page(...)` を `@member.posts.order(created_at: :desc).page(...)` に修正

## 目的
ユーザーが直近の投稿をすぐ確認できるようにするため。

## 補足
ロジックの変更は1行のみですが、表示体験としては明確な改善があるため、単独でのPRとしています。