### PR TITLE
Fix: 非表示ユーザーを除外したコメント一覧の描画処理を修正（destroy.js.erb）

### DIFF
--- a/app/views/public/comments/destroy.js.erb
+++ b/app/views/public/comments/destroy.js.erb
@@ -1,1 +1,1 @@
-$('.comments-index').html("<%= j(render 'public/comments/index', post: @comment.post) %>")
+$('.comments-index').html("<%= j(render 'public/comments/index', comments: @comment.post.comments.with_available_members) %>")


### PR DESCRIPTION
### 概要  
非同期コメント削除時（destroy.js.erb）に comments が未定義のためエラーが発生していた問題を修正しました。

### 背景  
コメント削除時に部分テンプレート public/comments/_index.html.erb を再描画する処理において、ローカル変数 comments が適切に渡されておらず、undefined local variable or method 'comments' のエラーが発生していました。  
以前の PR（#22・#25）にて、詳細画面表示およびコメント投稿後の再描画処理では、非表示ユーザーを除外した comments を明示的に渡すよう修正済みでしたが、destroy.js.erb の処理のみ未対応となっていました。

### 変更内容  
- destroy.js.erb における render 呼び出しを修正し、comments: @post.comments.with_available_members を渡すように変更。

### 目的  
非同期コメント削除後にエラーなくコメント一覧を再描画できるようにするため。

### 補足  
with_available_members を使用することで、退会済みユーザーのコメントが描画されない仕様も維持されています。