### PR TITLE
 Fix: ゲストログイン時のヘッダーアイコンの遷移先を修正

### DIFF
--- a/app/views/layouts/_guest_header.html.erb
+++ b/app/views/layouts/_guest_header.html.erb
@@ -1,7 +1,7 @@
 <header class="header">
   <nav class="navbar navbar-expand-lg bg-light navbar-light">
     <div class="container-fluid px-5">
-      <%= link_to root_path, class: "navbar-brand" do %>
+      <%= link_to posts_path, class: "navbar-brand" do %>
         <%= image_tag "tsunagari_logo_flower.png", alt: "つながり広場のロゴ", class: "header-logo-img" %>
       <% end %>
       <button class="navbar-toggler d-flex align-items-center d-lg-none" data-bs-toggle="collapse" data-bs-target="#navbarNav">


### PR DESCRIPTION
## 概要
ゲストログイン時、ヘッダーのアイコンからの遷移先が、意図しないURLに設定されていたため、ゲストログインユーザー用の正しい遷移先へ修正しました。

## 修正内容
- ヘッダーのリンク先を、ゲストユーザーログイン後の遷移先である投稿検索画面に変更

## 影響範囲
- ヘッダー表示部 `_guest_header.html.erb` 
- ナビゲーションのUX改善

## 補足
- 本修正は軽微なリンク修正のみであり、レイアウトやロジックの変更は伴いません。

