### PR TITLE
Fix: 投稿本文・コメント・通報理由の改行表示に対応

### DIFF
--- a/app/views/admin/reports/show.html.erb
+++ b/app/views/admin/reports/show.html.erb
@@ -20,7 +20,7 @@
         </tr>
         <tr>
           <th>理由</th>
-          <td><%= @report.reason %></td>
+          <td><%= simple_format(h(@report.reason)) %></td>
         </tr>
         <tr>
           <th>通報者</th>

--- a/app/views/public/comments/_index.html.erb
+++ b/app/views/public/comments/_index.html.erb
@@ -5,7 +5,7 @@
         <%= image_tag comment.member.get_profile_image(35,35), alt: "プロフィール画像", class: "rounded-circle me-2" %>
         <span class="text-nowrap"><%= comment.member.name %></span>
       <% end %>
-      <p class="mb-0 ms-3 text-break"><%= comment.comment_body %></p>
+      <div class="mb-0 ms-3 text-break"><%= simple_format(h(comment.comment_body)) %></div>
       <% if comment.member == current_member %>
         <div class="d-flex justify-content-end mt-2">
           <%= link_to "削除", post_comment_path(comment.post, comment),data: { confirm: "本当に削除してもよろしいですか？" }, method: :delete, remote: true, class: "btn btn-outline-danger btn-sm text-nowrap" %>

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -7,7 +7,7 @@
         </div>
         <div class="flex-grow-1">
           <h3><%= @member.name %></h3>
-          <p><%= @member.self_introduction %></p>
+          <div><%= simple_format(h(@member.self_introduction)) %></div>
           <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
             <% if current_member == @member %> 
               <%= link_to edit_member_registration_path, class: "btn btn-outline-dark btn-sm" do %>
@@ -53,7 +53,7 @@
     <div class="card-body">
       <h4 class="card-title"><%= post.title %></h4>
       <p class="card-text">投稿の種類：<%= post.genre.present? ? post.genre.name : "未選択" %></p>
-      <p class="card-text"><%= post.body %></p>
+      <div class="card-text"><%= simple_format(h(post.body)) %></div>
       <div class="text-end">
         <%= link_to "コメントはこちら", post_path(post), class: "btn btn-success btn-sm" %>
       </div>

--- a/app/views/public/posts/_post_list.html.erb
+++ b/app/views/public/posts/_post_list.html.erb
@@ -9,7 +9,7 @@
     <div class="card-body">
       <h4 class="card-title"><%= post.title %></h4>
       <p class="card-text">投稿の種類：<%= post.genre.present? ? post.genre.name : "未選択" %></p>
-      <p class="card-text"><%= post.body %></p>
+      <div class="card-text"><%= simple_format(h(post.body)) %></div>
       <div class="text-end">
         <%= link_to "コメントはこちら", post_path(post), class: "btn btn-success btn-sm" %>
       </div>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -24,7 +24,7 @@
     <div class="card-body">
       <h4 class="card-title"><%= @post.title %></h4>
       <p class="card-text">投稿の種類：<%= @post.genre.present? ? @post.genre.name : "未選択" %></p>
-      <p class="card-text"><%= @post.body %></p>
+      <div class="card-text"><%= simple_format(h(@post.body)) %></div>
     </div>
     <div class="container">
       <div class="w-100 mx-auto bg-light rounded-3 py-5 px-4 align-items-center justify-content-between">


### PR DESCRIPTION
## 概要  
現在、投稿本文に改行を含めて入力しても、詳細ページでは改行が反映されず、すべてが1行に連結されて表示されてしまいます。  
入力時の意図を反映するため、改行をそのまま表示するよう改善します。

## 背景  
- 箇条書きや段落分けなど、ユーザーが意図した書式が維持されない状態。
- 可読性や表現力を高めるために、改行の反映が必要です。

## 改善方針  
- 詳細ページの投稿本文表示箇所を以下のように修正予定：
`<div class="card-text"><%= simple_format(h(post.body)) %></div>`

## タスク
- [x] 該当箇所に simple_format(h(post.body)) を適用
- [x] 改行が反映されるか手動で検証（箇条書きや段落入力でテスト）

## 追加対応（スコープ拡大）
当初は投稿本文の改行対応のみを予定していましたが、同様の問題がコメント本文および通報理由文にも見られたため、以下の対応も同ブランチで実施しました。

- コメント本文の表示に `simple_format(h(comment.comment_body))` を適用
- 通報理由文の表示に `simple_format(h(report.reason))` を適用

表示面で一貫性を保つため、同時修正としています。

---

Closes #42
