### PR TITLE
Add: 投稿一覧・詳細ページ・コメント一覧に投稿日時の表示を追加 (Closes #40)

### DIFF
--- a/app/views/public/comments/_index.html.erb
+++ b/app/views/public/comments/_index.html.erb
@@ -6,6 +6,9 @@
         <span class="text-nowrap"><%= comment.member.name %></span>
       <% end %>
       <div class="mb-0 ms-3 text-break"><%= simple_format(h(comment.comment_body)) %></div>
+      <div class="d-flex justify-content-end small">
+        投稿日：<%= l(comment.created_at, format: :short) %>
+      </div>
       <% if comment.member == current_member %>
         <div class="d-flex justify-content-end mt-2">
           <%= link_to "削除", post_comment_path(comment.post, comment),data: { confirm: "本当に削除してもよろしいですか？" }, method: :delete, remote: true, class: "btn btn-outline-danger btn-sm text-nowrap" %>

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -54,6 +54,9 @@
       <h4 class="card-title"><%= post.title %></h4>
       <p class="card-text">投稿の種類：<%= post.genre.present? ? post.genre.name : "未選択" %></p>
       <div class="card-text"><%= simple_format(h(post.body)) %></div>
+      <div class="text-start small">
+        投稿日：<%= l(post.created_at, format: :short) %>
+      </div>
       <div class="text-end">
         <%= link_to "コメントはこちら", post_path(post), class: "btn btn-success btn-sm" %>
       </div>

--- a/app/views/public/posts/_post_list.html.erb
+++ b/app/views/public/posts/_post_list.html.erb
@@ -10,6 +10,9 @@
       <h4 class="card-title"><%= post.title %></h4>
       <p class="card-text">投稿の種類：<%= post.genre.present? ? post.genre.name : "未選択" %></p>
       <div class="card-text"><%= simple_format(h(post.body)) %></div>
+      <div class="text-start small">
+        投稿日：<%= l(post.created_at, format: :short) %>
+      </div>
       <div class="text-end">
         <%= link_to "コメントはこちら", post_path(post), class: "btn btn-success btn-sm" %>
       </div>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -25,6 +25,9 @@
       <h4 class="card-title"><%= @post.title %></h4>
       <p class="card-text">投稿の種類：<%= @post.genre.present? ? @post.genre.name : "未選択" %></p>
       <div class="card-text"><%= simple_format(h(@post.body)) %></div>
+      <div class="d-flex justify-content-end small">
+        投稿日：<%= l(@post.created_at, format: :short) %>
+      </div>
     </div>
     <div class="container">
       <div class="w-100 mx-auto bg-light rounded-3 py-5 px-4 align-items-center justify-content-between">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,7 @@
 ja:
+ time:
+    formats:
+      short: "%-Y/%-m/%-d"
  activerecord:
    models:
      member: メンバー


### PR DESCRIPTION
## 概要  
投稿一覧ページ・詳細ページ、およびコメント一覧部分において、各項目の投稿日時（created_at）を表示し、投稿・コメントの新しさや時系列を利用者が把握できるようにします。

## 背景  
現状の画面では、投稿やコメントがいつ作成されたのかが分からず、情報の鮮度や順序が把握できない状態です。  
特にコメントは複数存在する場合、時系列が分からないと読みづらく、ユーザーの判断材料として不十分です。

## 改善内容  
- 各投稿に `投稿日時：〇〇年〇月〇日` の形式で `created_at` を表示  
- 各コメントにも `投稿日時：〇〇年〇月〇日` の形式で `created_at` を表示  
- 表示形式は `l(created_at, format: :short)` や `strftime` などを使用予定  

## 目的  
- ユーザーが投稿やコメントの新旧・順序を把握しやすくする  
- 信頼性・透明性を高め、投稿の意味づけや行動判断に寄与する

## タスク  
- [x] 投稿一覧ページ（`app/views/public/posts/index.html.erb`）に `created_at` を表示  
- [x] 投稿詳細ページ（`app/views/public/posts/show.html.erb`）に `created_at` を表示  
- [x] コメント一覧（`app/views/public/comments/_index.html.erb` など）にも `created_at` を表示  
- [x] 表示形式を `l(..., format: :short)` または `strftime` を使って整える  
- [x] `config/locales/ja.yml` に `time.formats.short` が未定義なら追加（例: `"%-m/%-d %H:%M"`）  
- [x] テストデータを用いて投稿・コメントともに日時が正しく表示されることをブラウザ上で確認  
- [x] 必要に応じて CSS クラスやスタイルを調整して視認性やレイアウト崩れがないことを確認

## レイアウト方針についての補足

- 投稿詳細ページでは、周囲のコンテンツとのバランスを考慮し、投稿日時は「左揃え」で表示する。
- 投稿一覧ページでは、一覧性・視認性の観点から、右揃えで表示することで各カード間の整合性を保つ。
- 当初は「ユーザー名の横」に配置する案も検討したが、日付に年情報を含めるため文字列が長くなり、スマートフォン表示でレイアウトが崩れる懸念があるため、名前の下の行（最後の行）に追加する方針とした。
- 今回の実装では、モバイル環境での視認性や文字詰まりを防ぐため、最下部への配置とし、必要に応じてCSSの余白調整を行う。

---

Closes #40 