### PR TITLE
Add: ジャンル名の重複登録を防止するバリデーションを追加

### DIFF
--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,5 +1,5 @@
 class Genre < ApplicationRecord
   has_many :posts
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 end

--- a/db/migrate/20250725133545_add_index_to_genres_name_unique.rb
+++ b/db/migrate/20250725133545_add_index_to_genres_name_unique.rb
@@ -1,0 +1,5 @@
+class AddIndexToGenresNameUnique < ActiveRecord::Migration[6.1]
+  def change
+    add_index :genres, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_07_24_084745) do
+ActiveRecord::Schema.define(version: 2025_07_25_133545) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 2025_07_24_084745) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_genres_on_name", unique: true
   end
 
   create_table "members", force: :cascade do |t|


### PR DESCRIPTION
## 概要
ジャンルの新規登録時、現在は同一のジャンル名を複数回登録可能な状態となっている。  
ユーザーの混乱やデータの一貫性を防ぐため、ジャンル名の重複登録を禁止するバリデーションを追加。

## 改善内容
- `Genre`モデルに `name` カラムの一意性バリデーション（`uniqueness: { case_sensitive: false }`）を追加
- DBレベルでも `name` にユニークインデックスを追加
- 重複時には管理画面にエラーメッセージを表示
- 管理者画面での登録挙動、バリデーションの動作確認も実施

## 補足
一意性のバリデーションには `case_sensitive: false` を指定。  
今後、たとえば「筋萎縮性側索硬化症（ALS）」のような難病ジャンルを追加する際、  
`"ALS"`と`"als"`など大文字小文字の違いによる重複登録を防止するため。

## 目的
- 意図しないジャンルの重複を防止し、UI/UXの整合性を保つ
- システム上の混乱や検索ロジックの不具合を予防

## タスク
- [x] モデルにバリデーションを追加
- [x] マイグレーションでユニークインデックスを追加
- [x] 管理画面での登録動作確認
- [x] 重複時のエラーメッセージ表示確認

---

Closes #39 
