### PR TITLE
Add: 応援一覧ページに対象ユーザー名の表示を追加

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -88,6 +88,10 @@ input[type="radio"] {
     padding: 0.25rem 0.75rem;
   }
 
+  .follow-title {
+    font-size: 1.25rem;
+  }
+
   .title-responsive-sm.w-75,
   .title-responsive-sm.w-50,
   .content-responsive-sm.w-75,

--- a/app/views/public/members/followers.html.erb
+++ b/app/views/public/members/followers.html.erb
@@ -1,7 +1,7 @@
 <div class="border-bottom mt-4">
   <div class="container">
     <div class="w-50 mx-auto title-responsive-sm">
-      <h2 class="mb-4">応援されている人</h2>
+      <h3 class="follow-title mb-4"><%= "#{@member.name}を応援している人" %></h3>
     </div>
   </div>
 </div> 

--- a/app/views/public/members/followings.html.erb
+++ b/app/views/public/members/followings.html.erb
@@ -1,7 +1,7 @@
 <div class="border-bottom mt-4">
   <div class="container">
     <div class="w-50 mx-auto title-responsive-sm">
-      <h2 class="mb-4">応援している人</h2>
+      <h3 class="follow-title mb-4"><%= "#{@member.name}が応援している人" %></h3>
     </div>
   </div>
 </div> 


### PR DESCRIPTION
## 概要  
現在、「応援している人」および「応援されている人」の一覧ページでは、誰の応援関係を表示しているのかが明示されていません。  
他ユーザーのマイページを閲覧している際にも同様であるため、閲覧対象が誰かを明確に示す必要があります。

## 背景  
- マイページや他ユーザーの詳細ページから遷移した際、表示されている「応援している／されている」ユーザー一覧が誰のものなのかが不明確。
- 高齢者やデジタルに不慣れなユーザーにとっても、一覧の意図が明示されていた方が安心して利用できる。

## 改善方針  
- 一覧ページのタイトルまたは見出しに、対象ユーザーの名前を含めて表示する。  
  例：  
  - 「〇〇さんが応援している人一覧」  
  - 「〇〇さんを応援している人一覧」  

## タスク  
- [x] 応援一覧ビューで、対象ユーザー名付きのタイトルを表示する処理を追加
- [x] 表示パターン：「応援している人」／「応援されている人」の2種を条件分岐
- [x] 表示位置はページ上部
- [x] UI崩れが発生しないことを確認
- [x] 他ユーザー閲覧時も意図通り表示されるか手動確認

## 補足対応
- 長いユーザー名にも対応できるよう、見出しの文字サイズに専用クラスを付与し、メディアクエリによるレスポンシブ対応を実施。
  - モバイル画面でもタイトルが折り返されたりUIが崩れないよう調整済み。

---

Closes #43 
- スマホ表示でも1行表示を保ち、見出しの視認性を確保。
