### PR TITLE
Chore: 保存ボタン・エラーUIの調整とジャンルフォームの共通化

### DIFF
--- a/app/views/admin/genres/_form_field.html.erb
+++ b/app/views/admin/genres/_form_field.html.erb
@@ -1,0 +1,6 @@
+<div>
+  <%= f.label :name, "ジャンル名", class: "form-label fs-4 mb-0" %>
+</div>
+<div class="w-25">
+  <%= f.text_field :name, placeholder: "ジャンル名", class: "form-control form-control-lg w-100" %>
+</div>

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -1,16 +1,13 @@
 <div class="container">
-  <%= render 'shared/form_error_messages', object: @genre %>
+  <div class="w-50 mx-auto mb-4">
+    <%= render 'shared/form_error_messages', object: @genre %>
+  </div>
 
   <h3 class="text-center mb-4 mt-4 genre-heading">ジャンル編集</h3>
 
   <%= form_with model: @genre, url: admin_genre_path(@genre) do |f| %>
     <div class="d-flex justify-content-center align-items-center gap-3 mb-4">
-      <div>
-        <%= f.label :name, "ジャンル名", class: "form-label fs-4 mb-0" %>
-      </div>
-      <div class="w-25">
-        <%= f.text_field :name, placeholder: "ジャンル名", class: "form-control form-control-lg w-100" %>
-      </div>
+      <%= render 'form_field', f: f %>
       <div>
         <%= f.submit "変更を保存", class: "btn btn-success btn-lg" %>
       </div>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -1,13 +1,11 @@
 <div class="container mt-4 mb-4">
-  <%= render 'shared/form_error_messages', object: @genre %>
+  <div class="w-50 mx-auto mb-4">
+    <%= render 'shared/form_error_messages', object: @genre %>
+  </div>
+
   <%= form_with model: @genre, url: admin_genres_path do |f| %>
     <div class="d-flex justify-content-center align-items-center gap-3 mb-4">
-      <div>
-        <%= f.label :name, "ジャンル名", class: "form-label fs-4 mb-0" %>
-      </div>
-      <div class="w-25">
-        <%= f.text_field :name, placeholder: "ジャンル名", class: "form-control form-control-lg w-100" %>   
-      </div>
+      <%= render 'form_field', f: f %>
       <div>
         <%= f.submit "新規登録", class: "btn btn-success btn-lg" %>
       </div>

--- a/app/views/public/posts/_save_button.html.erb
+++ b/app/views/public/posts/_save_button.html.erb
@@ -1,10 +1,10 @@
 <% if @post.saved_post_by?(current_member) %>
   <%= link_to post_saved_post_path(@post), method: :delete, remote: true, class: "btn btn-success btn-sm" do %>
-    <i class="fa-solid fa-bookmark"></i>保存解除
+    <i class="fa-solid fa-bookmark me-1"></i>保存解除
   <% end %>
 <% else %>
   <%= link_to post_saved_post_path(@post), method: :post, remote: true, class: "btn btn-outline-success btn-sm" do %>
-    <i class="fa-regular fa-bookmark"></i>保存
+    <i class="fa-regular fa-bookmark me-1"></i>保存
   <% end %>
 <% end %>
 


### PR DESCRIPTION
## 概要  
UIの微調整およびコードの可読性向上を目的としたリファクタリングを行いました。

## 変更内容  

- 保存ボタンのUI調整 
　→ `<i class="fa-regular fa-bookmark"></i>保存` のアイコンと文字の間にマージンを追加し、視認性を改善しました。

- アラート表示（成功/エラー）のデザイン統一（管理者画面）  
　→ `alert-success` と `alert-danger` の表示幅・位置を `w-50 mx-auto` に統一し、画面全体のレイアウトバランスを改善しました。

- ジャンル登録フォームの一部を部分テンプレート化 
　→ `ジャンル名の入力欄` を `app/views/admin/genres/_form_field.html.erb` に切り出し、他の管理画面との再利用性と保守性を向上させました。

## 補足  
- アラート表示の幅調整により、画面中央にエラーや成功メッセージが揃って表示されるようになります。  
- 部分テンプレート化の範囲はフォームの一部に限定され、submitボタンとの結合関係を崩さないよう配慮しています。

---

Closes #49 

