### PR TITLE
Refactor: Member#exceeded_report_limit? を削除

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -46,10 +46,6 @@ class Member < ApplicationRecord
     Report.where(reported_id: id).count
   end
 
-  def exceeded_report_limit?
-    report_count >= 3
-  end
-
   GUEST_MEMBER_EMAIL = "guest@example.com"
 
   def self.guest


### PR DESCRIPTION
## 概要
Member#exceeded_report_limit? は report_count >= 3 を返すだけのメソッドですが、現在どこからも参照されていません。
同一の判定ロジックは Report#update_user_status に存在するため、重複コードを削除しました。

## 背景
- 判定ロジック（3回以上で停止）は Report#update_user_status に集約済み
- 未使用メソッドを残すと保守性が下がるため削除

## タスク
- [x] app/models/member.rb の exceeded_report_limit? メソッドを削除する（未使用のため）。

## 動作確認
- 既存のテストを実行し、全てパスすることを確認済み
- Report#update_user_status 側でユーザーステータスの更新が正しく行われることを確認済み

----
Closes #56 




