### PR TITLE
Refactor: Postモデルのコメント通知処理を簡素化

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -26,20 +26,15 @@ class Post < ApplicationRecord
   end
 
   def create_notification_comment(current_member, comment_id)
-    return if member_id == current_member.id  
-    save_notification_comment(current_member, comment_id, member_id)
-  end
-
-  def save_notification_comment(current_member, comment_id, visited_id)
+    # 自己コメントなら通知なし
+    return if member_id == current_member.id
+  
     notification = current_member.active_notifications.new(
       post_id: id,
       comment_id: comment_id,
-      visited_id: visited_id,
+      visited_id: member_id, 
       action: 'comment'
     )
-    if notification.visitor_id == notification.visited_id
-      notification.checked = true
-    end
     notification.save if notification.valid?
   end
 end


### PR DESCRIPTION
## 概要
コメント通知処理の重複や使われない条件分岐を取り除き、コードを読みやすく・管理しやすくする。

## 解決策
冗長なメソッドを統合し、単一のメソッドにすることで、コードをシンプルかつ効率的にします。
具体的には、create_notification_comment と save_notification_comment の両方を、新しい create_notification_comment に統合します。

## タスク
- [x] create_notification_comment にロジックを統合する（save_notification_comment を削除）。
- [x] 自己通知は作らない方針を明示する（return if member_id == current_member.id を残す）。
- [x] visited_id は常に投稿者の member_id をモデル内部で直接代入し、呼び出し側は current_member と comment_id だけ渡せば済むようにする。
- [x] 新しいメソッドが正しく機能することを確認するため、テストを実施する。

----
#58 