### PR TITLE
Perf: N+1問題の包括的な解決とパフォーマンス改善

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'bullet'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,9 @@ GEM
       kaminari (>= 0.13)
       rails (>= 3.1)
     builder (3.3.0)
+    bullet (8.0.8)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (12.0.0)
     capybara (3.40.0)
       addressable
@@ -247,6 +250,7 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uniform_notifier (1.17.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -278,6 +282,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   bootstrap5-kaminari-views (~> 0.0.1)
+  bullet
   byebug
   capybara (>= 3.26)
   devise

--- a/app/controllers/public/members_controller.rb
+++ b/app/controllers/public/members_controller.rb
@@ -36,8 +36,8 @@ class Public::MembersController < ApplicationController
                                  .merge(Member.available)
                                  .includes(
                                    :genre, 
-                                   { image_attachment: { blob: :variant_records } },                      # Post -> image
-                                   { member: { profile_image_attachment: { blob: :variant_records } } }   # Member -> profile_image
+                                   { image_attachment: :blob },                      # Post -> image
+                                   { member: { profile_image_attachment: :blob } }   # Member -> profile_image
                                  )
                                  .order('saved_posts.created_at DESC')
                                  .page(params[:page])

--- a/app/controllers/public/members_controller.rb
+++ b/app/controllers/public/members_controller.rb
@@ -35,11 +35,11 @@ class Public::MembersController < ApplicationController
   end
 
   def followings
-    @followings = @member.followings.only_available.page(params[:page]).per(15)
+    @followings = @member.followings.only_available_with_avatar.page(params[:page]).per(15)
   end
 
   def followers
-    @followers = @member.followers.only_available.page(params[:page]).per(15)
+    @followers = @member.followers.only_available_with_avatar.page(params[:page]).per(15)
   end
 
   private

--- a/app/controllers/public/members_controller.rb
+++ b/app/controllers/public/members_controller.rb
@@ -31,23 +31,16 @@ class Public::MembersController < ApplicationController
 
   def saved_posts
     # ページ分のPostを取得（在籍メンバーに限定）
-    base_scope = current_member.saved_posts_posts
-                               .joins(:member)                 # 在籍フィルタ用の結合
-                               .merge(Member.available)
-                               .order('saved_posts.created_at DESC')
-
-    @saved_posts = base_scope.page(params[:page])
-
-    # N+1一掃：結果集合に対して必要な関連を明示プリロード
-    # Active Recordの関連付けを効率的に事前読み込みするためのクラス
-    ActiveRecord::Associations::Preloader.new.preload(
-      @saved_posts,
-      [
-        :genre,                                            # Post -> Genre
-        { image_attachment: { blob: :variant_records } },  # Post -> image
-        { member: { profile_image_attachment: :blob } }    # Post -> Member -> profile_image
-      ]
-    )
+    @saved_posts = current_member.saved_posts_posts
+                                 .joins(:member)                 # 在籍フィルタ用の結合
+                                 .merge(Member.available)
+                                 .includes(
+                                   :genre, 
+                                   { image_attachment: { blob: :variant_records } },                      # Post -> image
+                                   { member: { profile_image_attachment: { blob: :variant_records } } }   # Member -> profile_image
+                                 )
+                                 .order('saved_posts.created_at DESC')
+                                 .page(params[:page])
   end
 
   def followings

--- a/app/controllers/public/notifications_controller.rb
+++ b/app/controllers/public/notifications_controller.rb
@@ -11,6 +11,9 @@ class Public::NotificationsController < ApplicationController
 
     # 表示はアクティブユーザーからのみに限定
     base_scope = current_member.passive_notifications.joins(:visitor).merge(Member.available).order(created_at: :desc)
-    @notifications = base_scope.includes(:visitor, :post, :comment).page(params[:page]).per(15) 
+    @notifications = base_scope.includes(
+      { visitor: { profile_image_attachment: :blob } },
+      { comment: { member: { profile_image_attachment: :blob } } }
+      ).page(params[:page]).per(15) 
   end
 end

--- a/app/controllers/public/notifications_controller.rb
+++ b/app/controllers/public/notifications_controller.rb
@@ -12,8 +12,10 @@ class Public::NotificationsController < ApplicationController
     # 表示はアクティブユーザーからのみに限定
     base_scope = current_member.passive_notifications.joins(:visitor).merge(Member.available).order(created_at: :desc)
     @notifications = base_scope.includes(
-      { visitor: { profile_image_attachment: :blob } },
-      { comment: { member: { profile_image_attachment: :blob } } }
+      :visited,
+      :post, 
+      :comment, 
+      { visitor: { profile_image_attachment: :blob } }
       ).page(params[:page]).per(15) 
   end
 end

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -40,8 +40,16 @@ class Public::PostsController < ApplicationController
   end
 
   def followings
-    following_ids = current_member.following_ids
-    @posts = Post.with_available_members.where(member_id: following_ids).order(created_at: :desc).page(params[:page])
+    @posts = current_member.followed_posts.with_available_members.order(created_at: :desc).page(params[:page])
+    
+    ActiveRecord::Associations::Preloader.new.preload(
+      @posts,
+      [
+        :genre,                                            # Post -> Genre
+        { image_attachment: { blob: :variant_records } },  # Post -> image
+        { member: { profile_image_attachment: :blob } }    # Post -> Member -> profile_image
+      ]
+    )
   end
 
   def edit

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -1,9 +1,9 @@
 class Public::PostsController < ApplicationController
   before_action :restrict_to_member!
   before_action :restrict_guest_member, except: [:index, :show]
-  before_action :set_post, only: [:show, :edit, :update, :destroy]
+  before_action :set_post, only: [:edit, :update, :destroy]
   before_action :is_matching_login_user, only: [:edit, :update]
-  before_action :set_genres, only: [:index, :new, :edit, :create, :update, :show]
+  before_action :set_genres, only: [:index, :new, :edit, :create, :update]
   
   def new
     @post = Post.new
@@ -35,6 +35,7 @@ class Public::PostsController < ApplicationController
   end
 
   def show
+    @post = Post.with_available_members_for_list.find(params[:id])
     @comment = Comment.new
     @comments = @post.comments.with_available_members
   end

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -20,7 +20,7 @@ class Public::PostsController < ApplicationController
   end
 
   def index
-    @posts = Post.with_available_members
+    @posts = Post.with_available_members_for_list
 
     if params[:keyword].present?
       kw = "%#{params[:keyword]}%"
@@ -40,16 +40,7 @@ class Public::PostsController < ApplicationController
   end
 
   def followings
-    @posts = current_member.followed_posts.with_available_members.order(created_at: :desc).page(params[:page])
-    
-    ActiveRecord::Associations::Preloader.new.preload(
-      @posts,
-      [
-        :genre,                                            # Post -> Genre
-        { image_attachment: { blob: :variant_records } },  # Post -> image
-        { member: { profile_image_attachment: :blob } }    # Post -> Member -> profile_image
-      ]
-    )
+    @posts = current_member.followed_posts.with_available_members_for_list.order(created_at: :desc).page(params[:page])
   end
 
   def edit

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,7 +3,7 @@ class Comment < ApplicationRecord
   belongs_to :post
 
   scope :with_available_members, -> {
-    joins(:member).merge(Member.available).includes(:member)
+    joins(:member).merge(Member.available).includes(member: { profile_image_attachment: { blob: :variant_records } })
   }
 
   validates :comment_body, presence: true, length: { maximum: 300 }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,7 +3,7 @@ class Comment < ApplicationRecord
   belongs_to :post
 
   scope :with_available_members, -> {
-    joins(:member).merge(Member.available).includes(member: { profile_image_attachment: { blob: :variant_records } })
+    joins(:member).merge(Member.available).includes(member: { profile_image_attachment: :blob })
   }
 
   validates :comment_body, presence: true, length: { maximum: 300 }

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -27,6 +27,7 @@ class Member < ApplicationRecord
   has_many :passive_relationships, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
   has_many :followings, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships,source: :follower
+  has_many :followed_posts, through: :followings, source: :posts
   has_many :active_notifications, class_name: 'Notification', foreign_key: 'visitor_id', dependent: :destroy
   has_many :passive_notifications, class_name: 'Notification', foreign_key: 'visited_id', dependent: :destroy
   has_many :reports_made, class_name: "Report", foreign_key: "reporter_id", dependent: :destroy

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -18,8 +18,6 @@ class Member < ApplicationRecord
 
   enum user_status: { available: 0, suspended: 1 }
 
-  scope :available, -> { where(user_status: :available) }
-
   has_one_attached :profile_image, dependent: :destroy  
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
@@ -38,8 +36,10 @@ class Member < ApplicationRecord
   validates :self_introduction, length: { maximum: 500 }, allow_blank: true, on: :update_profile
   validates :user_status, presence: true
 
-  scope :only_available, -> {
-    merge(Member.available)
+  scope :available, -> { where(user_status: :available) }
+
+  scope :only_available_with_avatar, -> {
+    merge(Member.available).with_attached_profile_image
   }
 
   def report_count

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,8 +14,8 @@ class Post < ApplicationRecord
     .merge(Member.available)
     .includes(
       :genre,
-      { image_attachment: { blob: :variant_records } },
-      { member: { profile_image_attachment: { blob: :variant_records } } }
+      { image_attachment: :blob },
+      { member: { profile_image_attachment: :blob } }
     )
   }
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,8 +9,14 @@ class Post < ApplicationRecord
   validates :title, presence: true, length: { maximum: 30 }
   validates :body, presence: true, length: { maximum: 1000 }
   
-  scope :with_available_members, -> {
-    joins(:member).merge(Member.available).includes(:member, :genre)
+  scope :with_available_members_for_list, -> {
+  joins(:member)
+    .merge(Member.available)
+    .includes(
+      :genre,
+      { image_attachment: { blob: :variant_records } },
+      { member: { profile_image_attachment: { blob: :variant_records } } }
+    )
   }
 
   def get_image(width, height)

--- a/app/views/public/comments/_index.html.erb
+++ b/app/views/public/comments/_index.html.erb
@@ -2,7 +2,7 @@
   <div class="d-flex flex-column flex-md-row border-bottom align-items-start justify-content-between py-3 gap-2">
     <div class="d-flex flex-column w-100">
       <%= link_to member_path(comment.member), class: "text-decoration-none link-dark d-flex align-items-center mb-2 me-3" do %>
-        <%= image_tag comment.member.get_profile_image(35,35), alt: "プロフィール画像", class: "rounded-circle me-2" %>
+        <%= image_tag comment.member.profile_image.variant(resize_to_fit: [35, 35]), alt: "プロフィール画像", class: "rounded-circle me-2" %>
         <span class="text-nowrap"><%= comment.member.name %></span>
       <% end %>
       <div class="mb-0 ms-3 text-break"><%= simple_format(h(comment.comment_body)) %></div>

--- a/app/views/public/notifications/_notifications.html.erb
+++ b/app/views/public/notifications/_notifications.html.erb
@@ -8,7 +8,7 @@
         <div class="d-flex align-items-start">
           <div class="me-2">
             <%= link_to member_path(visitor), class: "text-decoration-none" do %>
-              <%= image_tag visitor.get_profile_image(40, 40), class: "rounded-circle" %>
+              <%= image_tag visitor.profile_image.variant(resize_to_fit: [40, 40]), class: "rounded-circle" %>
             <% end %>
           </div>
           <div class="flex-grow-1">

--- a/app/views/public/posts/_post_list.html.erb
+++ b/app/views/public/posts/_post_list.html.erb
@@ -4,7 +4,7 @@
      <%= render 'shared/member_summary', member: post.member %>
     </div>
 
-    <%= image_tag post.get_image(600, 500), alt: "投稿画像", class: "card-img-top", style: "max-height: 500px; object-fit: cover;" %>
+    <%= image_tag post.image.variant(resize_to_fill: [600, 500]), alt: "投稿画像", class: "card-img-top", style: "max-height: 500px; object-fit: cover;" %>
     
     <div class="card-body">
       <h4 class="card-title"><%= post.title %></h4>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -20,7 +20,7 @@
         </div>
       <% end %>
     </div>
-    <%= image_tag @post.get_image(600,500), alt: "投稿画像", class: "card-img-top" %>
+    <%= image_tag @post.image.variant(resize_to_fit: [600, 500]), alt: "投稿画像", class: "card-img-top" %>
     <div class="card-body">
       <h4 class="card-title"><%= @post.title %></h4>
       <p class="card-text">投稿の種類：<%= @post.genre.present? ? @post.genre.name : "未選択" %></p>

--- a/app/views/shared/_member_summary.html.erb
+++ b/app/views/shared/_member_summary.html.erb
@@ -1,11 +1,11 @@
 <% if current_member&.guest? %>
   <div class="text-decoration-none link-dark d-flex align-items-center">
-    <%= image_tag member.get_profile_image(50, 50), alt: "プロフィール画像", class: "rounded-circle me-3" %>
+    <%= image_tag member.profile_image.variant(resize_to_fill: [50, 50]), alt: "プロフィール画像", class: "rounded-circle me-3" %>
     <span class="text-break"><%= member.name %></span>
   </div>
 <% else %>
   <%= link_to member_path(member), class: "text-decoration-none link-dark d-flex align-items-center" do %>
-    <%= image_tag member.get_profile_image(50, 50), alt: "プロフィール画像", class: "rounded-circle me-3" %>
+    <%= image_tag member.profile_image.variant(resize_to_fill: [50, 50]), alt: "プロフィール画像", class: "rounded-circle me-3" %>
     <span class="text-break"><%= member.name %></span>
   <% end %>
 <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,14 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  config.after_initialize do
+    Bullet.enable = true          # bulletを有効化
+    Bullet.alert = true           # ブラウザのJavaScriptアラートで警告
+    Bullet.bullet_logger = true   # Railsのログに警告を出力
+    Bullet.console = true         # ブラウザのコンソールに警告を出力
+    Bullet.rails_logger = true    # Railsのログに警告を出力
+  end
+
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 


### PR DESCRIPTION
## 概要
フォロー一覧、フォロワー一覧、通知一覧など、複数の画面でN+1問題が発生していました。特に、投稿（Post）、投稿者（Member）、ジャンル（Genre）などの関連データを取得する際に、不要なデータベースクエリが繰り返し発行されており、パフォーマンスが低下していました。

## 解決策
- `includes`を使用し、必要な関連データを事前にまとめて読み込むことで、データベースへのクエリ回数を削減しました。
- 特に、Active Storageで管理されている画像 (image_attachment, profile_image_attachment) を効率的に読み込み、ビューでの不要なクエリ発行を防ぎました。

## タスク
- [x] フォロー一覧 (/members/follows)
- [x] フォロワー一覧 (/members/followers)
- [x] 通知一覧 (/notifications/index)
- [x] 検索結果一覧 (/posts/index)
- [x] 保存した投稿一覧 (/members/saved_posts)
- [x] 投稿詳細 (/posts/show)
- [x] フォローした人の投稿一覧(/posts/followings)
- [x] **Bullet gemで検出された追加のN+1問題をすべて解消**

## 修正内容
- **フォロワー投稿一覧の修正**
  フォロワーの投稿一覧（`/posts/followings`）で発生していたN+1問題を解決するため、`member.rb`に`has_many :followed_posts, through: :followings, source: :posts`という関連付けを追加しました。これにより、ActiveRecordの効率的なクエリを活用し、不要なデータベースクエリをなくしました。

- **`variant`メソッドでのN+1問題解消とActive Storageの最適化**
  これまでの画像表示は、ビューが表示されるたびに「画像があるか？」そして「リサイズされた画像があるか？」をそれぞれ問い合わせていました。
  そこで、コントローラーで`includes`を使って必要な画像データを一括で読み込み、ビューでは`image_tag post.image.variant(...)`のように`variant`メソッドで直接リサイズを指示する形に変更しました。この変更により、ビューの描画中にデータベースへの問い合わせが発生しなくなり、ページ表示速度が大幅に改善されました。

- **Bullet gemによる追加修正**
  **Bullet gem**を導入し、既存の修正でカバーしきれなかったN+1問題や、不必要なEager Loadingを解消しました。特に、以下のような問題を解決しました。
    - 通知一覧画面における`Notification`と`visitor`、`comment`、そして`profile_image_attachment`や`blob`といった複数の関連モデルにわたる複雑なN+1問題を解消。
    - 保存した投稿一覧画面で発生していた、`variant_records`の無駄な事前読み込みを削除。

## ブランチ名と対応範囲の補足
このイシューを立てた時のブランチ名 `perf/preload-member-avatars` は、当初の目的を反映しています。しかし、その後の作業で対応範囲を拡大し、Bullet gemの導入とそれによる網羅的な修正を実行しました。今回の修正は、当初の目的であるプロフィール画像のアバター読み込みだけでなく、より包括的なN+1問題の解決になっています。

----
Closes #57 