### PR TITLE
CI導入: GitHub ActionsでRSpecを自動実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       RAILS_ENV: test
       DISABLE_SPRING: 1
       RAILS_LOG_TO_STDOUT: true
+      RUBYOPT: -rlogger
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     env:
       RAILS_ENV: test
       DISABLE_SPRING: 1
+      RAILS_LOG_TO_STDOUT: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       RAILS_ENV: test
       DISABLE_SPRING: 1
       RAILS_LOG_TO_STDOUT: true
-      RUBYOPT: -rlogger
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+      DISABLE_SPRING: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Prepare DB
+        run: |
+          bin/rails db:create
+          bin/rails db:schema:load
+
+      - name: Run RSpec
+        run: bundle exec rspec --format progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Prepare DB
         run: |
-          bin/rails db:create
-          bin/rails db:schema:load
+          bundle exec rails db:create
+          bundle exec rails db:schema:load
 
       - name: Run RSpec
         run: bundle exec rspec --format progress

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require 'logger'
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
## 概要
Rails プロジェクトに GitHub Actions を導入し、push および Pull Request 時に RSpec が自動実行されるようにしました。
これにより、テストが常に緑であることを確認しながら開発を進められる基盤を整えます。

## タスク
- [x] github/workflows/ci.yml を作成
- [x] Ruby / Bundler のセットアップを追加
- [x] rails db:create db:schema:load をジョブに追加
- [x] bundle exec rspec を実行するステップを追加
- [x] GitHub Actions 上で CI が動作し、RSpec が自動で実行されて緑になる。
- [x] プルリクエスト時に CI の結果が確認できる。

## 今回の方針(最小構成)
- RSpec実行のみ に絞ったミニマムな構成
- SQLite のため追加サービス不要
- System spec が無いため、ブラウザや Node.js のセットアップも省略

## 今後の改善ポイント（必要になった場合は別Issue化）
- DB準備の統一
  - db:create + db:schema:load を rails db:prepare に一本化
- 失敗時の解析を容易に
  - rspec_junit_formatter を導入し、JUnit形式で結果を出力
  - GitHub Actions の artifact にレポートを保存
- Node依存が出た場合の対応
  - package.json / yarn.lock が追加されたら actions/setup-node を導入し yarn install をステップに追加
- 安定性の強化
  - --order random オプションで順序依存の潜在バグ検出
  - CI のタイムゾーンが UTC なので、時刻依存テストを避ける工夫が必要

## CI失敗の原因と対処
CI 実行時に `uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger` が発生して失敗していた件を修正しました。

## 対応内容
- `config/boot.rb` に `require 'logger'` を追加し、Rails 起動時に Logger を明示的にロードするように修正。
- （参考） https://zenn.dev/ayu0819/articles/3d361c5a14c2df

## 備考
- `RAILS_LOG_TO_STDOUT: true` はログ出力を見やすくするための補助設定であり、本件の根本解決策ではありません。
----
Closes #63